### PR TITLE
CLI & Worker Cleanup

### DIFF
--- a/cli/actions/vault/export.ts
+++ b/cli/actions/vault/export.ts
@@ -4,6 +4,7 @@ import { syncEnv } from 'lib/env';
 import { logInfo } from 'lib/log';
 import { resolve } from 'path';
 import { cwd } from 'process';
+import { Env } from 'types/config';
 
 // TODO format support (.env, JSON files)
 export async function vaultExport(
@@ -22,15 +23,22 @@ export async function vaultExport(
   });
 
   const secrets = await getAllSecrets();
-  const secretsMap = secrets.reduce(
-    (prev, { name, value }) => (prev += `${name}="${value}"\n`),
-    ``,
-  );
 
   logInfo(`Secrets retrieved for '${vaultNameInput}' vault!`);
-  console.log(secretsMap);
 
   const fullEnvPath = resolve(cwd(), envDestinationPath);
 
-  console.log(fullEnvPath);
+  const secretsMap: Env = secrets.reduce(
+    (prev, { name, value }) => ({
+      ...prev,
+      [name]: value,
+    }),
+    {},
+  );
+
+  await syncEnv(fullEnvPath, secretsMap);
+
+  logInfo(
+    `Secrets successfully exported to '${envDestinationPath}'!`,
+  );
 }

--- a/cli/types/config.ts
+++ b/cli/types/config.ts
@@ -13,3 +13,5 @@ export type DeadropConfig = {
   active_vault: string;
   vaults: VaultStore;
 };
+
+export type Env = Record<string, string>;

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -9,12 +9,12 @@ export enum ContentType {
   Json = 'application/json',
 }
 
-export enum PeerJsRoutes {
-  Index = '/',
-  PeerJs = '/peerjs',
-  GenerateId = '/peerjs/id',
-}
-
-export enum DeadropRoutes {
+export enum AppRoutes {
+  Root = '/',
   Drop = '/drop',
+
+  // peerjs paths
+  PeerJsRoot = '/peerjs',
+  PeerJsGenerateId = '/peerjs/id',
+  GenerateId = '/id',
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,32 +1,24 @@
 import { PeerServerDO } from './lib/durable_objects';
 import { cors, tracing } from './lib/middleware';
 import { hono } from './lib/http/core';
-import { PeerJsRoutes } from './constants';
-
-const WELCOME_TEXT = JSON.stringify({
-  name: 'PeerJS Server',
-  description:
-    'A server side element to broker connections between PeerJS clients.',
-  website: 'https://peerjs.com/',
-});
+import { AppRoutes } from './constants';
+import peersRouter from './routers/peers';
 
 const app = hono();
 
 app.use(cors());
 app.use(tracing());
 
-app.get(PeerJsRoutes.Index, (c) => c.text(WELCOME_TEXT));
+app.get(AppRoutes.Root, (c) =>
+  c.json({
+    name: 'deadrop API',
+    description:
+      'A serverless API to handle drops and peer connection brokering',
+    website: 'https://deadrop.io/',
+  }),
+);
 
-app.get(PeerJsRoutes.PeerJs, (c) => {
-  const url = new URL(c.req.url);
-
-  const objId = c.env.PEER_SERVER.idFromName(url.host);
-  const stub = c.env.PEER_SERVER.get(objId);
-
-  return stub.fetch(c.req.raw);
-});
-
-app.get(PeerJsRoutes.GenerateId, (c) => c.text(crypto.randomUUID()));
+app.route(AppRoutes.PeerJsRoot, peersRouter);
 
 export default {
   fetch: app.fetch,

--- a/worker/src/lib/middleware.ts
+++ b/worker/src/lib/middleware.ts
@@ -15,6 +15,7 @@ export const cors = (): Middleware =>
   baseCors({
     origin: [
       'https://deadrop.io',
+      'https://*.deadrop.io',
       'https://*nieky-allens-projects.vercel.app',
       'https://*nieky.vercel.app',
     ],

--- a/worker/src/routers/peers.ts
+++ b/worker/src/routers/peers.ts
@@ -1,0 +1,17 @@
+import { AppRoutes } from '../constants';
+import { hono } from '../lib/http/core';
+
+const peersRouter = hono();
+
+peersRouter.get(AppRoutes.Root, (c) => {
+  const url = new URL(c.req.url);
+
+  const objId = c.env.PEER_SERVER.idFromName(url.host);
+  const stub = c.env.PEER_SERVER.get(objId);
+
+  return stub.fetch(c.req.raw);
+});
+
+peersRouter.get(AppRoutes.GenerateId, (c) => c.text(crypto.randomUUID()));
+
+export default peersRouter;


### PR DESCRIPTION
# Changelog

- update CLI vault export action and types
- refactor `worker` to use a router pattern for the peerjs endpoints
- cleanup `PeerServerDO`
- extend CORS config to support `*.deadrop.io` domains