### PR TITLE
CLI-issued CI keys, read-only vault fix, inject scoping flags

### DIFF
--- a/.changeset/cli-apikey-reveal.md
+++ b/.changeset/cli-apikey-reveal.md
@@ -2,6 +2,6 @@
 'cli': minor
 ---
 
-`deadrop apiKeys create` now shows the key on an alternate screen — the same one `less` and `vim` use — so it leaves nothing behind in your terminal scrollback once you dismiss it. Press Enter after copying and it is gone.
+`deadrop apiKeys create` now hands back both variables a pipeline needs — the API key and the environment's `DEADROP_VAULT_KEY` — instead of leaving you to dig the second out of `.deadroprc`. They are shown on an alternate screen, the same one `less` and `vim` use, so nothing is left in your terminal scrollback once you dismiss it.
 
-Two escapes for when you want the raw value: `--copy` puts it straight on your clipboard without displaying it at all, and `--print` writes it to stdout so it can be piped. Writing a key to a non-interactive stream now requires `--print` rather than happening by default, so a script or agent capturing output cannot pick one up by accident.
+`--copy` puts both on your clipboard without displaying them, and `--print` writes them to stdout so they can be piped. Writing to a non-interactive stream now requires `--print` rather than happening by default, so a script or agent capturing output cannot pick a key up by accident.

--- a/.changeset/cli-apikey-reveal.md
+++ b/.changeset/cli-apikey-reveal.md
@@ -1,0 +1,7 @@
+---
+'cli': minor
+---
+
+`deadrop apiKeys create` now shows the key on an alternate screen — the same one `less` and `vim` use — so it leaves nothing behind in your terminal scrollback once you dismiss it. Press Enter after copying and it is gone.
+
+Two escapes for when you want the raw value: `--copy` puts it straight on your clipboard without displaying it at all, and `--print` writes it to stdout so it can be piped. Writing a key to a non-interactive stream now requires `--print` rather than happening by default, so a script or agent capturing output cannot pick one up by accident.

--- a/.changeset/cli-init-global.md
+++ b/.changeset/cli-init-global.md
@@ -1,0 +1,5 @@
+---
+'cli': minor
+---
+
+`deadrop init --global` initializes deadrop in your OS app-data directory rather than the current one. That is the config the CLI falls back to when a project has no `.deadroprc` of its own, and the same one the desktop app uses — until now it could only be created by the desktop app or by grabbing a shared vault.

--- a/.changeset/cli-inject-only-prefix.md
+++ b/.changeset/cli-inject-only-prefix.md
@@ -1,0 +1,7 @@
+---
+'cli': minor
+---
+
+`deadrop inject` gains `--only` and `--prefix`, so one environment can serve jobs that need different slices of it. `--only NAME,NAME` injects just those secrets and fails on a name the environment does not have, rather than silently injecting nothing. `--prefix VITE_` renames every injected variable, so a value can be stored once and handed to a bundler that expects its own prefix.
+
+`--only` matches the names as stored, so the list reads the same as `vault env list`; `--prefix` applies afterwards.

--- a/.changeset/cli-readonly-cloud-vault.md
+++ b/.changeset/cli-readonly-cloud-vault.md
@@ -1,0 +1,5 @@
+---
+'cli': patch
+---
+
+Fix `deadrop inject` failing on a read-only cloud vault with "SQL write operations are forbidden". It bootstrapped the `secrets` table on every connection, which a read-only sync token rejects — so a CI run using an API key, or anyone reading a vault shared with them, could not open the replica at all. Cloud vaults already carry that table from Turso, so it is only created for local ones now.

--- a/.changeset/cli-readonly-cloud-vault.md
+++ b/.changeset/cli-readonly-cloud-vault.md
@@ -2,4 +2,6 @@
 'cli': patch
 ---
 
-Fix `deadrop inject` failing on a read-only cloud vault with "SQL write operations are forbidden". It bootstrapped the `secrets` table on every connection, which a read-only sync token rejects — so a CI run using an API key, or anyone reading a vault shared with them, could not open the replica at all. Cloud vaults already carry that table from Turso, so it is only created for local ones now.
+Fix `deadrop inject` failing on a read-only cloud vault with "SQL write operations are forbidden". It bootstrapped the `secrets` table on every connection, which a read-only sync token rejects — so a CI run using an API key, or anyone reading a vault shared with them, could not open the vault at all. Cloud vaults already carry that table from Turso, so it is only created for local ones now.
+
+Replication is a write too, so `--no-sync` reads the cloud vault directly over the network instead of building a local replica. That is the right mode for a cold read in CI, where the replica is a throwaway and there is nothing to keep in sync.

--- a/.github/workflows/desktop_ci_workflow.yml
+++ b/.github/workflows/desktop_ci_workflow.yml
@@ -43,16 +43,17 @@ jobs:
       - name: Check desktop version sync
         run: pnpm -F desktop sync-version --check
 
-      # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
+      - name: Install deadrop
+        run: npm install -g deadrop
+
+      # Build config comes from the vault environment the API key is scoped
+      # to, which holds the prod values under their VITE_ names — never the
+      # dev `vars.*`, since dev Clerk creds against the prod Worker break auth.
       - name: Build desktop frontend
         env:
-          VITE_DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
-          VITE_PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
-          VITE_TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
-          VITE_TURN_PWD: ${{ secrets.TURN_PWD }}
-          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
-          VITE_WEB_URL: ${{ secrets.DEADROP_APP_URL }}
-        run: pnpm -F desktop build
+          DEADROP_API_KEY: ${{ secrets.DEADROP_API_KEY }}
+          DEADROP_VAULT_KEY: ${{ secrets.DEADROP_VAULT_KEY }}
+        run: deadrop inject --ci -- pnpm -F desktop build
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/desktop_ci_workflow.yml
+++ b/.github/workflows/desktop_ci_workflow.yml
@@ -43,17 +43,16 @@ jobs:
       - name: Check desktop version sync
         run: pnpm -F desktop sync-version --check
 
-      - name: Install deadrop
-        run: npm install -g deadrop
-
-      # Build config comes from the vault environment the API key is scoped
-      # to, which holds the prod values under their VITE_ names — never the
-      # dev `vars.*`, since dev Clerk creds against the prod Worker break auth.
+      # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
       - name: Build desktop frontend
         env:
-          DEADROP_API_KEY: ${{ secrets.DEADROP_API_KEY }}
-          DEADROP_VAULT_KEY: ${{ secrets.DEADROP_VAULT_KEY }}
-        run: deadrop inject --ci -- pnpm -F desktop build
+          VITE_DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
+          VITE_PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
+          VITE_TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
+          VITE_TURN_PWD: ${{ secrets.TURN_PWD }}
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          VITE_WEB_URL: ${{ secrets.DEADROP_APP_URL }}
+        run: pnpm -F desktop build
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Hono routes:
 
 ### CLI (`cli/`)
 
-- Commands: `drop`, `grab`, `init`, `login`, `logout`, `whoami`, `update`, `inject`, `desktop install`, `vault` (create/list/use/sync/export/import/drop/delete/env), `secret` (add/remove)
+- Commands: `drop`, `grab`, `init`, `login`, `logout`, `whoami`, `update`, `inject`, `desktop install`, `vault` (create/list/use/sync/export/import/drop/delete/env), `secret` (add/remove), `apiKeys` (create)
 - Local secrets storage: Drizzle ORM + SQLite (libsql)
 - Build: esbuild → `dist/deadrop.js`; optional standalone binary via nexe
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -40,7 +40,7 @@ cli/
 ## CLI Commands
 
 ```
-deadrop init            # First-time setup
+deadrop init            # First-time setup (--global for the shared app-data config)
 deadrop login           # Authenticate with Clerk
 deadrop logout
 deadrop whoami           # Check signed-in identity
@@ -49,6 +49,7 @@ deadrop desktop install # Install (or update) the deadrop desktop app (macOS/Win
 deadrop drop            # Share a secret (drives dropMachine)
 deadrop grab            # Receive a secret (drives grabMachine)
 deadrop inject           # Run a command with vault secrets injected as env vars
+                        # (--ci for API-key auth, --only/--prefix to narrow and rename)
 deadrop vault create    # Create a local vault (seeds development + production envs)
 deadrop vault list      # List all vaults in the config
 deadrop vault use       # Switch active vault (--environment to also switch env; prompts to select when name omitted)
@@ -61,6 +62,7 @@ deadrop vault env list  # List environments in the active vault
 deadrop vault env add   # Add a new environment (fresh key) to the active vault
 deadrop secret add      # Add secret to vault
 deadrop secret remove
+deadrop apiKeys create  # Issue a CI key scoped to one cloud vault + environment
 ```
 
 ## Key Patterns

--- a/cli/actions/apiKeys.ts
+++ b/cli/actions/apiKeys.ts
@@ -1,15 +1,25 @@
 import { confirm, select } from '@inquirer/prompts';
 import { VaultStore } from '@shared/types/config';
 import chalk from 'chalk';
+import { copyToClipboard } from 'lib/clipboard';
 import { createDeadropClient } from 'lib/api';
 import { loadConfig } from 'lib/config';
-import { logDebug, logError, logInfo, logWarning } from 'lib/log';
+import {
+  canReveal,
+  logDebug,
+  logError,
+  logInfo,
+  logWarning,
+  revealSecret,
+} from 'lib/log';
 import { exit } from 'process';
 
 type CreateApiKeyOptions = {
   vault?: string;
   environment?: string;
   yes?: boolean;
+  print?: boolean;
+  copy?: boolean;
 };
 
 // A key mints Turso tokens for a remote database, so a local-only vault
@@ -82,6 +92,55 @@ async function pickEnvironment(
   });
 }
 
+// The key is shown once and is never retrievable again, so the default is
+// the alternate screen — it leaves nothing behind in scrollback. Raw stdout
+// is opt-in, since that is the path a pipe or a capturing agent reads.
+async function handOffKey(
+  name: string,
+  environment: string,
+  key: string,
+  options: CreateApiKeyOptions,
+) {
+  const pairWith =
+    `Pair it with the '${environment}' DEADROP_VAULT_KEY ` +
+    'in your CI secrets.';
+
+  if (options.copy) {
+    if (await copyToClipboard(key)) {
+      logInfo(
+        `Created '${chalk.bold(name)}', copied to your clipboard.`,
+      );
+      logWarning(pairWith);
+      return;
+    }
+
+    logWarning(
+      'Could not reach a clipboard, showing the key instead.',
+    );
+  }
+
+  if (options.print) {
+    process.stdout.write(`${key}\n`);
+    return;
+  }
+
+  if (!canReveal()) {
+    logError(
+      'Refusing to print an API key to a non-interactive stream. Run ' +
+        'this in a terminal, or pass --print to pipe it deliberately.',
+    );
+    return exit(1);
+  }
+
+  await revealSecret({
+    title: `Created '${name}' — this is the only time it is shown.`,
+    value: `DEADROP_API_KEY=${key}`,
+    hint: pairWith,
+  });
+
+  logInfo(`Created '${chalk.bold(name)}'`);
+}
+
 export async function createApiKey(
   options: CreateApiKeyOptions = {},
 ) {
@@ -135,12 +194,7 @@ export async function createApiKey(
       key: string;
     };
 
-    logInfo(`Created '${chalk.bold(name)}'`);
-    logInfo(`DEADROP_API_KEY=${chalk.bold(key)}`);
-    logWarning(
-      'Copy this now, it is not retrievable later. Pair it with the ' +
-        `'${environment}' DEADROP_VAULT_KEY in your CI secrets.`,
-    );
+    await handOffKey(name, environment, key, options);
 
     return exit(0);
   } catch (err) {

--- a/cli/actions/apiKeys.ts
+++ b/cli/actions/apiKeys.ts
@@ -97,30 +97,30 @@ async function pickEnvironment(
 // is opt-in, since that is the path a pipe or a capturing agent reads.
 async function handOffKey(
   name: string,
-  environment: string,
   key: string,
+  vaultKey: string,
   options: CreateApiKeyOptions,
 ) {
-  const pairWith =
-    `Pair it with the '${environment}' DEADROP_VAULT_KEY ` +
-    'in your CI secrets.';
+  // Both are needed together and neither is useful alone, so hand over the
+  // pair rather than making the caller dig the vault key out of .deadroprc.
+  const pair = `DEADROP_API_KEY=${key}\nDEADROP_VAULT_KEY=${vaultKey}`;
 
   if (options.copy) {
-    if (await copyToClipboard(key)) {
+    if (await copyToClipboard(pair)) {
       logInfo(
-        `Created '${chalk.bold(name)}', copied to your clipboard.`,
+        `Created '${chalk.bold(name)}', copied both values to your ` +
+          'clipboard.',
       );
-      logWarning(pairWith);
       return;
     }
 
     logWarning(
-      'Could not reach a clipboard, showing the key instead.',
+      'Could not reach a clipboard, showing the values instead.',
     );
   }
 
   if (options.print) {
-    process.stdout.write(`${key}\n`);
+    process.stdout.write(`${pair}\n`);
     return;
   }
 
@@ -133,9 +133,9 @@ async function handOffKey(
   }
 
   await revealSecret({
-    title: `Created '${name}' — this is the only time it is shown.`,
-    value: `DEADROP_API_KEY=${key}`,
-    hint: pairWith,
+    title: `Created '${name}' — this is the only time the API key is shown.`,
+    value: pair,
+    hint: 'Add both to your CI secrets.',
   });
 
   logInfo(`Created '${chalk.bold(name)}'`);
@@ -194,7 +194,12 @@ export async function createApiKey(
       key: string;
     };
 
-    await handOffKey(name, environment, key, options);
+    await handOffKey(
+      name,
+      key,
+      config.vaults[vaultName].environments[environment],
+      options,
+    );
 
     return exit(0);
   } catch (err) {

--- a/cli/actions/init.ts
+++ b/cli/actions/init.ts
@@ -2,8 +2,13 @@ import { confirm } from '@inquirer/prompts';
 import { initDBClient } from 'db/init';
 import { existsSync } from 'fs';
 import { appendFile, mkdir } from 'fs/promises';
-import { initConfig, loadConfig, saveConfig } from 'lib/config';
+import {
+  initConfig,
+  loadConfigFromPath,
+  saveConfig,
+} from 'lib/config';
 import { CONFIG_FILE_NAME } from '@shared/lib/constants';
+import { globalConfigDir } from 'lib/global-config';
 import { logInfo } from 'lib/log';
 import { resolve } from 'path';
 import { cwd } from 'process';
@@ -12,30 +17,47 @@ import {
   STORAGE_DIR_NAME,
 } from '@shared/lib/constants';
 
-export default async function (options: { yes?: boolean } = {}) {
-  const defaultConfigPath = resolve(cwd(), CONFIG_FILE_NAME);
-  const defaultVaultPath = resolve(
-    STORAGE_DIR_NAME,
-    DEFAULT_VAULT_NAME,
-  );
+export default async function (
+  options: { yes?: boolean; global?: boolean } = {},
+) {
+  // The global dir is what loadConfig falls back to, and the same one the
+  // desktop app writes — an init there is shared between both.
+  const targetDir = options.global ? globalConfigDir() : cwd();
+
+  const defaultConfigPath = resolve(targetDir, CONFIG_FILE_NAME);
+  const storageDir = resolve(targetDir, STORAGE_DIR_NAME);
+  const defaultVaultPath = resolve(storageDir, DEFAULT_VAULT_NAME);
+
+  if (!existsSync(targetDir))
+    await mkdir(targetDir, { recursive: true });
 
   const defaultConfig = await initConfig(defaultVaultPath);
 
-  await saveConfig(cwd(), defaultConfig);
+  await saveConfig(targetDir, defaultConfig);
 
-  // validate it can be loaded
-  const { config } = await loadConfig();
+  // Validate the file just written, not whatever loadConfig would discover
+  // — a project-scoped .deadroprc in cwd would shadow a global init.
+  const { config } = await loadConfigFromPath(defaultConfigPath);
 
-  if (!existsSync(STORAGE_DIR_NAME))
-    await mkdir(STORAGE_DIR_NAME, { recursive: true });
+  if (!existsSync(storageDir))
+    await mkdir(storageDir, { recursive: true });
 
   const { location } = config.vaults.default;
 
   // TODO consider writing NODE_ENV to vault
   const db = await initDBClient(location);
 
-  logInfo(`Default vault initalized & config created at '${defaultConfigPath}'!
-We recommend adding the following to your .gitignore:
+  logInfo(
+    `Default vault initalized & config created at '${defaultConfigPath}'!`,
+  );
+
+  // Nothing to ignore outside a project directory.
+  if (options.global) {
+    logInfo('Deadrop setup complete!');
+    process.exit(0);
+  }
+
+  logInfo(`We recommend adding the following to your .gitignore:
 ${CONFIG_FILE_NAME}
 ${STORAGE_DIR_NAME}/`);
 

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -26,6 +26,7 @@ type InjectOptions = {
   ci?: boolean;
   only?: string;
   prefix?: string;
+  sync?: boolean;
 };
 
 type ResolvedVault = {
@@ -264,7 +265,11 @@ export async function inject(
   const { vaultName, environment, vault, ephemeral } =
     await parseVaultFromOptions(options);
 
-  const db = await initDBClient(vault.location, vault.cloud);
+  const db = await initDBClient(
+    vault.location,
+    vault.cloud,
+    options.sync,
+  );
 
   const { getAllSecrets } = createSecretsHelpers(vault, db);
 

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -24,6 +24,8 @@ type InjectOptions = {
   refreshToken?: boolean;
   verbose?: boolean;
   ci?: boolean;
+  only?: string;
+  prefix?: string;
 };
 
 type ResolvedVault = {
@@ -210,6 +212,44 @@ async function parseVaultFromOptions(options: InjectOptions) {
   return resolved;
 }
 
+// --only names the stored secrets, so the list matches `vault env list`;
+// --prefix is applied after, renaming whatever survived the filter.
+function shapeSecrets(
+  secrets: Record<string, string>,
+  { only, prefix }: InjectOptions,
+) {
+  let shaped = secrets;
+
+  if (only) {
+    const wanted = only
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean);
+
+    const missing = wanted.filter((name) => !(name in secrets));
+
+    // A typo here would otherwise inject nothing and exit 0.
+    if (missing.length) {
+      logError(`Not in this environment: ${missing.join(', ')}`);
+      process.exit(1);
+    }
+
+    shaped = Object.fromEntries(
+      wanted.map((name) => [name, secrets[name]]),
+    );
+  }
+
+  if (prefix)
+    shaped = Object.fromEntries(
+      Object.entries(shaped).map(([name, value]) => [
+        `${prefix}${name}`,
+        value,
+      ]),
+    );
+
+  return shaped;
+}
+
 export async function inject(
   command: string[],
   options: InjectOptions,
@@ -228,7 +268,10 @@ export async function inject(
 
   const { getAllSecrets } = createSecretsHelpers(vault, db);
 
-  const secrets = await getAllSecrets(environment);
+  const secrets = shapeSecrets(
+    await getAllSecrets(environment),
+    options,
+  );
 
   const names = Object.keys(secrets);
 

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -52,6 +52,10 @@ deadrop
     '-y, --yes',
     'skip prompts and accept defaults (also implied by a non-TTY shell or CI)',
   )
+  .option(
+    '--global',
+    'initialize globally instead of in the current directory',
+  )
   .action(init);
 
 deadrop.command('login').action(login);

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -275,6 +275,14 @@ use it as DEADROP_API_KEY with 'deadrop inject --ci'`,
     '-y, --yes',
     'skip the confirmation prompt (also implied by a non-TTY shell or CI)',
   )
+  .option(
+    '--print',
+    'write the key to stdout instead of showing it on a scrollback-free screen',
+  )
+  .option(
+    '--copy',
+    'copy the key to your clipboard without showing it',
+  )
   .action(createApiKey);
 
 export { deadrop };

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -118,6 +118,10 @@ deadrop
     'mint a fresh read-only Turso token for CI/CD via /vault/tokens/ci',
   )
   .option(
+    '--no-sync',
+    'read the cloud vault directly instead of replicating it locally',
+  )
+  .option(
     '--only <names>',
     'inject only these secrets, comma-separated',
   )

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -117,6 +117,14 @@ deadrop
     '--ci',
     'mint a fresh read-only Turso token for CI/CD via /vault/tokens/ci',
   )
+  .option(
+    '--only <names>',
+    'inject only these secrets, comma-separated',
+  )
+  .option(
+    '--prefix <prefix>',
+    'prepend this to every injected variable name',
+  )
   .option('--verbose', 'log injected variable names (never values)')
   .action(inject);
 

--- a/cli/db/init.ts
+++ b/cli/db/init.ts
@@ -11,17 +11,13 @@ export const initDBClient = async (
   path: string,
   cloudConfig?: CloudVaultConfig,
 ) => {
-  const [config, drizzleConfig] = initDBConfig(
-    path,
-    cloudConfig,
-  );
+  const [config, drizzleConfig] = initDBConfig(path, cloudConfig);
 
   const client = drizzle(createClient(config), drizzleConfig);
 
-  // Cloud vaults sync their schema from Turso; local file dbs can't sync.
+  // Turso provisions the table; a read-only token forbids the write.
   if (cloudConfig) await syncWithRetry(client.$client);
-
-  await ensureSecretsSchema(client.$client);
+  else await ensureSecretsSchema(client.$client);
 
   return client;
 };

--- a/cli/db/init.ts
+++ b/cli/db/init.ts
@@ -10,14 +10,20 @@ import { drizzle } from 'drizzle-orm/libsql/node';
 export const initDBClient = async (
   path: string,
   cloudConfig?: CloudVaultConfig,
+  sync: boolean = true,
 ) => {
-  const [config, drizzleConfig] = initDBConfig(path, cloudConfig);
+  const [config, drizzleConfig] = initDBConfig(
+    path,
+    cloudConfig,
+    sync,
+  );
 
   const client = drizzle(createClient(config), drizzleConfig);
 
-  // Turso provisions the table; a read-only token forbids the write.
-  if (cloudConfig) await syncWithRetry(client.$client);
-  else await ensureSecretsSchema(client.$client);
+  // Replication and CREATE TABLE are both writes a read-only token blocks.
+  if (cloudConfig) {
+    if (sync) await syncWithRetry(client.$client);
+  } else await ensureSecretsSchema(client.$client);
 
   return client;
 };

--- a/cli/lib/clipboard.ts
+++ b/cli/lib/clipboard.ts
@@ -1,0 +1,29 @@
+import { spawn } from 'child_process';
+
+// Value is piped over stdin, never passed as an argument — argv is visible
+// to any process listing.
+const COPY_COMMAND: Record<string, [string, string[]]> = {
+  darwin: ['pbcopy', []],
+  win32: ['clip.exe', []],
+  linux: ['xclip', ['-selection', 'clipboard']],
+};
+
+export function copyToClipboard(value: string): Promise<boolean> {
+  const command = COPY_COMMAND[process.platform];
+
+  if (!command) return Promise.resolve(false);
+
+  const [cmd, args] = command;
+
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      stdio: ['pipe', 'ignore', 'ignore'],
+    });
+
+    // xclip is not installed by default on every distro.
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+
+    child.stdin.end(value);
+  });
+}

--- a/cli/lib/log/index.ts
+++ b/cli/lib/log/index.ts
@@ -1,2 +1,3 @@
 export * from './loader';
+export * from './reveal';
 export * from './text';

--- a/cli/lib/log/reveal.ts
+++ b/cli/lib/log/reveal.ts
@@ -1,0 +1,39 @@
+import { input } from '@inquirer/prompts';
+import chalk from 'chalk';
+
+// Alternate screen buffer, the same one less/vim use. Anything drawn here
+// is discarded on exit rather than joining scrollback — clearing lines
+// after the fact would not, since scrolled output is already committed.
+const ALT_SCREEN_ON = '\x1b[?1049h';
+const ALT_SCREEN_OFF = '\x1b[?1049l';
+
+type RevealOptions = {
+  title: string;
+  value: string;
+  hint?: string;
+};
+
+export const canReveal = () => Boolean(process.stdout.isTTY);
+
+export async function revealSecret({
+  title,
+  value,
+  hint,
+}: RevealOptions) {
+  process.stdout.write(ALT_SCREEN_ON);
+
+  try {
+    console.log(chalk.cyan(title) + '\n');
+    console.log(value + '\n');
+
+    if (hint) console.log(chalk.yellow(hint) + '\n');
+
+    await input({
+      message: 'Press Enter once you have copied it',
+    });
+  } finally {
+    // Restore even on Ctrl-C or a render failure; a terminal stuck in the
+    // alternate buffer looks broken.
+    process.stdout.write(ALT_SCREEN_OFF);
+  }
+}

--- a/cli/tests/unit/db-init.spec.ts
+++ b/cli/tests/unit/db-init.spec.ts
@@ -3,8 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const ensureSecretsSchema = vi.fn();
 const syncWithRetry = vi.fn();
 
+const initDBConfig = vi.fn((path: string) => [
+  { url: `file:${path}` },
+  {},
+]);
+
 vi.mock('@shared/db/init', () => ({
-  initDBConfig: (path: string) => [{ url: `file:${path}` }, {}],
+  initDBConfig: (...args: unknown[]) =>
+    (initDBConfig as any)(...args),
   ensureSecretsSchema,
   syncWithRetry,
 }));
@@ -41,5 +47,60 @@ describe('initDBClient', () => {
 
     expect(ensureSecretsSchema).toHaveBeenCalled();
     expect(syncWithRetry).not.toHaveBeenCalled();
+  });
+
+  // Replicating is itself a write, so a read-only token needs a path that
+  // never touches the local replica at all.
+  it('skips replication entirely with sync off', async () => {
+    const { initDBClient } = await import('db/init');
+
+    await initDBClient(
+      '/tmp/replica.db',
+      { name: 'a1b2c3d4e5f67-my-app', authToken: 'read-only-jwt' },
+      false,
+    );
+
+    expect(syncWithRetry).not.toHaveBeenCalled();
+    expect(ensureSecretsSchema).not.toHaveBeenCalled();
+    expect(initDBConfig).toHaveBeenCalledWith(
+      '/tmp/replica.db',
+      expect.anything(),
+      false,
+    );
+  });
+});
+
+describe('initDBConfig', () => {
+  it('points straight at Turso when sync is off', async () => {
+    const actual =
+      await vi.importActual<typeof import('@shared/db/init')>(
+        '@shared/db/init',
+      );
+
+    const [config] = actual.initDBConfig(
+      '/tmp/replica.db',
+      { name: 'a1b2c3d4e5f67-my-app', authToken: 'read-only-jwt' },
+      false,
+    );
+
+    expect(config.url).toContain('a1b2c3d4e5f67-my-app');
+    expect(config.authToken).toBe('read-only-jwt');
+    // No local file, so nothing to replicate into.
+    expect(config.syncUrl).toBeUndefined();
+  });
+
+  it('builds a replica with sync on', async () => {
+    const actual =
+      await vi.importActual<typeof import('@shared/db/init')>(
+        '@shared/db/init',
+      );
+
+    const [config] = actual.initDBConfig('/tmp/replica.db', {
+      name: 'a1b2c3d4e5f67-my-app',
+      authToken: 'jwt',
+    });
+
+    expect(config.url).toBe('file:/tmp/replica.db');
+    expect(config.syncUrl).toContain('a1b2c3d4e5f67-my-app');
   });
 });

--- a/cli/tests/unit/db-init.spec.ts
+++ b/cli/tests/unit/db-init.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ensureSecretsSchema = vi.fn();
+const syncWithRetry = vi.fn();
+
+vi.mock('@shared/db/init', () => ({
+  initDBConfig: (path: string) => [{ url: `file:${path}` }, {}],
+  ensureSecretsSchema,
+  syncWithRetry,
+}));
+
+vi.mock('@libsql/client', () => ({
+  createClient: vi.fn(() => ({})),
+}));
+
+vi.mock('drizzle-orm/libsql/node', () => ({
+  drizzle: vi.fn(() => ({ $client: {} })),
+}));
+
+describe('initDBClient', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // CREATE TABLE is a write, which a read-only token forbids — it broke CI
+  // and would break any grabbed shared vault the same way.
+  it('does not write a schema to a cloud vault', async () => {
+    const { initDBClient } = await import('db/init');
+
+    await initDBClient('/tmp/replica.db', {
+      name: 'a1b2c3d4e5f67-my-app',
+      authToken: 'read-only-jwt',
+    });
+
+    expect(syncWithRetry).toHaveBeenCalled();
+    expect(ensureSecretsSchema).not.toHaveBeenCalled();
+  });
+
+  it('bootstraps the schema for a local vault, which cannot sync', async () => {
+    const { initDBClient } = await import('db/init');
+
+    await initDBClient('/tmp/local.db');
+
+    expect(ensureSecretsSchema).toHaveBeenCalled();
+    expect(syncWithRetry).not.toHaveBeenCalled();
+  });
+});

--- a/cli/tests/unit/global-config.spec.ts
+++ b/cli/tests/unit/global-config.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const homedir = vi.fn();
+
+vi.mock('os', () => ({ homedir }));
+
+const withPlatform = (platform: NodeJS.Platform) =>
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+
+const realPlatform = process.platform;
+
+describe('globalConfigDir', () => {
+  afterEach(() => {
+    withPlatform(realPlatform);
+    delete process.env.APPDATA;
+    delete process.env.XDG_DATA_HOME;
+    vi.clearAllMocks();
+  });
+
+  // The identifier has to match desktop's tauri.conf.json, or the CLI and
+  // the app silently keep separate global vaults.
+  it('uses Application Support on macOS', async () => {
+    const { globalConfigDir } = await import('lib/global-config');
+
+    homedir.mockReturnValue('/Users/ada');
+    withPlatform('darwin');
+
+    expect(globalConfigDir()).toBe(
+      '/Users/ada/Library/Application Support/com.deadrop',
+    );
+  });
+
+  it('uses APPDATA on Windows', async () => {
+    const { globalConfigDir } = await import('lib/global-config');
+
+    homedir.mockReturnValue('C:\\Users\\ada');
+    withPlatform('win32');
+    process.env.APPDATA = 'C:\\Users\\ada\\AppData\\Roaming';
+
+    expect(globalConfigDir()).toContain('com.deadrop');
+    expect(globalConfigDir()).toContain('Roaming');
+  });
+
+  it('falls back to AppData/Roaming when APPDATA is unset', async () => {
+    const { globalConfigDir } = await import('lib/global-config');
+
+    homedir.mockReturnValue('C:\\Users\\ada');
+    withPlatform('win32');
+
+    expect(globalConfigDir()).toContain('AppData');
+    expect(globalConfigDir()).toContain('Roaming');
+  });
+
+  it('honors XDG_DATA_HOME on Linux', async () => {
+    const { globalConfigDir } = await import('lib/global-config');
+
+    homedir.mockReturnValue('/home/ada');
+    withPlatform('linux');
+    process.env.XDG_DATA_HOME = '/home/ada/.xdg';
+
+    expect(globalConfigDir()).toBe('/home/ada/.xdg/com.deadrop');
+  });
+
+  it('falls back to ~/.local/share on Linux', async () => {
+    const { globalConfigDir } = await import('lib/global-config');
+
+    homedir.mockReturnValue('/home/ada');
+    withPlatform('linux');
+
+    expect(globalConfigDir()).toBe(
+      '/home/ada/.local/share/com.deadrop',
+    );
+  });
+});
+
+describe('globalConfigPath', () => {
+  afterEach(() => withPlatform(realPlatform));
+
+  it('appends the config filename to the dir', async () => {
+    const { globalConfigPath } = await import('lib/global-config');
+
+    homedir.mockReturnValue('/Users/ada');
+    withPlatform('darwin');
+
+    expect(globalConfigPath()).toBe(
+      '/Users/ada/Library/Application Support/com.deadrop/.deadroprc',
+    );
+  });
+});

--- a/cli/tests/unit/init.spec.ts
+++ b/cli/tests/unit/init.spec.ts
@@ -1,0 +1,119 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('lib/log', () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  displayWelcomeMessage: vi.fn(),
+}));
+
+vi.mock('db/init', () => ({
+  initDBClient: vi.fn().mockResolvedValue({
+    $client: { close: vi.fn() },
+  }),
+}));
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn().mockResolvedValue(false),
+}));
+
+// Real filesystem: the whole point is where the file actually lands, which
+// a mocked fs would assert nothing about.
+describe('init --global', () => {
+  let home: string;
+  let projectDir: string;
+  const realCwd = process.cwd();
+  const realHome = process.env.HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    home = mkdtempSync(join(tmpdir(), 'deadrop-home-'));
+    projectDir = mkdtempSync(join(tmpdir(), 'deadrop-proj-'));
+    // os.homedir() reads $HOME on POSIX, which is what globalConfigDir uses.
+    process.env.HOME = home;
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(realCwd);
+    if (realHome) process.env.HOME = realHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('writes the config into the OS app-data dir, not the cwd', async () => {
+    const init = (await import('actions/init')).default;
+    const { globalConfigPath, globalConfigDir } =
+      await import('lib/global-config');
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await init({ global: true, yes: true });
+
+    expect(existsSync(globalConfigPath())).toBe(true);
+    expect(existsSync(join(globalConfigDir(), '.deadrop'))).toBe(
+      true,
+    );
+    // A global init must not leave anything behind in the project.
+    expect(existsSync(join(projectDir, '.deadroprc'))).toBe(false);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockRestore();
+  });
+
+  it('points the default vault at the global dir', async () => {
+    const init = (await import('actions/init')).default;
+    const { loadConfigFromPath } = await import('lib/config');
+    const { globalConfigPath, globalConfigDir } =
+      await import('lib/global-config');
+    vi.spyOn(process, 'exit').mockImplementation(
+      () => undefined as never,
+    );
+
+    await init({ global: true, yes: true });
+
+    const { config } = await loadConfigFromPath(globalConfigPath());
+
+    expect(config.vaults.default.location).toContain(
+      globalConfigDir(),
+    );
+  });
+
+  it('writes into the cwd without the flag', async () => {
+    const init = (await import('actions/init')).default;
+    const { globalConfigPath } = await import('lib/global-config');
+    vi.spyOn(process, 'exit').mockImplementation(
+      () => undefined as never,
+    );
+
+    await init({ yes: false });
+
+    expect(existsSync(join(projectDir, '.deadroprc'))).toBe(true);
+    expect(existsSync(globalConfigPath())).toBe(false);
+  });
+
+  // The dir does not exist on a machine that has never run the desktop app.
+  it('creates the app-data dir when it is missing', async () => {
+    const init = (await import('actions/init')).default;
+    const { globalConfigDir } = await import('lib/global-config');
+    vi.spyOn(process, 'exit').mockImplementation(
+      () => undefined as never,
+    );
+
+    expect(existsSync(globalConfigDir())).toBe(false);
+
+    await init({ global: true, yes: true });
+
+    expect(existsSync(globalConfigDir())).toBe(true);
+  });
+});

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -821,6 +821,144 @@ describe('inject', () => {
       expect(existsSync(`${replicaPath}${suffix}`)).toBe(false);
   });
 
+  // A shared preview/prod environment holds a superset, so a given job
+  // narrows and renames rather than getting its own environment.
+  const injectWithSecrets = async (
+    secrets: Record<string, string>,
+    options: Record<string, unknown>,
+  ) => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } =
+      await import('@shared/db/secrets');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'preview' },
+        vaults: {
+          default: { location: './vault.db', environments: {} },
+        },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close: vi.fn() },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue(secrets),
+    } as any);
+
+    const runWithEnvSpy = vi
+      .spyOn(processModule, 'runWithEnv')
+      .mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(
+      () => undefined as never,
+    );
+
+    await inject(['node'], { override: true, ...options });
+
+    return runWithEnvSpy;
+  };
+
+  it('--only injects just the named secrets', async () => {
+    const runWithEnv = await injectWithSecrets(
+      { API_URL: 'a', TURN_PWD: 'b', UNRELATED: 'c' },
+      { only: 'API_URL,TURN_PWD' },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({
+      API_URL: 'a',
+      TURN_PWD: 'b',
+    });
+  });
+
+  it('--only tolerates whitespace between names', async () => {
+    const runWithEnv = await injectWithSecrets(
+      { API_URL: 'a', TURN_PWD: 'b' },
+      { only: 'API_URL, TURN_PWD' },
+    );
+
+    expect(Object.keys(runWithEnv.mock.calls[0][2])).toEqual([
+      'API_URL',
+      'TURN_PWD',
+    ]);
+  });
+
+  it('--only exits 1 on a name the environment does not have', async () => {
+    const { logError } = await import('lib/log');
+    const { inject } = await import('actions/inject');
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } =
+      await import('@shared/db/secrets');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'preview' },
+        vaults: {
+          default: { location: './vault.db', environments: {} },
+        },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close: vi.fn() },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue({ API_URL: 'a' }),
+    } as any);
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => {
+        throw new Error('exit');
+      });
+
+    await expect(
+      inject(['node'], { override: true, only: 'API_URL,TYPOED' }),
+    ).rejects.toThrow('exit');
+
+    // A typo would otherwise inject nothing and exit 0.
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('TYPOED'),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('--prefix renames every injected variable', async () => {
+    const runWithEnv = await injectWithSecrets(
+      { DEADROP_API_URL: 'a', WEB_URL: 'b' },
+      { prefix: 'VITE_' },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({
+      VITE_DEADROP_API_URL: 'a',
+      VITE_WEB_URL: 'b',
+    });
+  });
+
+  it('--only filters on stored names, then --prefix renames', async () => {
+    const runWithEnv = await injectWithSecrets(
+      { DEADROP_API_URL: 'a', WEB_URL: 'b', SERVER_ONLY: 'c' },
+      { only: 'DEADROP_API_URL,WEB_URL', prefix: 'VITE_' },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({
+      VITE_DEADROP_API_URL: 'a',
+      VITE_WEB_URL: 'b',
+    });
+  });
+
+  it('injects everything when neither flag is given', async () => {
+    const runWithEnv = await injectWithSecrets(
+      { A: '1', B: '2' },
+      {},
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({ A: '1', B: '2' });
+  });
+
   it('config-based: never deletes the real vault db file', async () => {
     const { loadConfig } = await import('lib/config');
     const { initDBClient } = await import('db/init');

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -282,10 +282,11 @@ describe('inject', () => {
     // The local label is sent; the worker prefixes it into a remote name.
     expect(mintVaultToken).toHaveBeenCalledWith('default');
     // cloud is rebuilt from the mint, so the sync URL uses the remote name.
-    expect(initDBClient).toHaveBeenCalledWith('./vault.db', {
-      name: 'a1b2c3d4e5f67-default',
-      authToken: 'minted-token',
-    });
+    expect(initDBClient).toHaveBeenCalledWith(
+      './vault.db',
+      { name: 'a1b2c3d4e5f67-default', authToken: 'minted-token' },
+      undefined,
+    );
     expect(runWithEnvSpy).toHaveBeenCalledWith(
       'node',
       ['-e', 'process.exit(3)'],
@@ -339,7 +340,11 @@ describe('inject', () => {
     await inject(['node'], { override: true });
 
     expect(mintVaultToken).not.toHaveBeenCalled();
-    expect(initDBClient).toHaveBeenCalledWith('./vault.db', cloud);
+    expect(initDBClient).toHaveBeenCalledWith(
+      './vault.db',
+      cloud,
+      undefined,
+    );
   });
 
   it('local vault (no cloud config): does not mint, reads locally', async () => {
@@ -375,6 +380,7 @@ describe('inject', () => {
     expect(mintVaultToken).not.toHaveBeenCalled();
     expect(initDBClient).toHaveBeenCalledWith(
       './vault.db',
+      undefined,
       undefined,
     );
   });
@@ -426,10 +432,11 @@ describe('inject', () => {
     await inject(['node'], { override: true, refreshToken: true });
 
     expect(mintVaultToken).toHaveBeenCalledWith('default');
-    expect(initDBClient).toHaveBeenCalledWith('./vault.db', {
-      name: 'a1b2c3d4e5f67-default',
-      authToken: 'refreshed-token',
-    });
+    expect(initDBClient).toHaveBeenCalledWith(
+      './vault.db',
+      { name: 'a1b2c3d4e5f67-default', authToken: 'refreshed-token' },
+      undefined,
+    );
   });
 
   it('surfaces VaultNotFoundError cleanly instead of the generic message', async () => {
@@ -620,6 +627,7 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith(
       expect.stringContaining('deadrop-inject-'),
       { name: 'a1b2c3d4e5f67-my-app', authToken: 'ci-token' },
+      undefined,
     );
     expect(
       vi.mocked(createSecretsHelpers).mock.calls[0][0],

--- a/desktop/scripts/sync-version.js
+++ b/desktop/scripts/sync-version.js
@@ -15,6 +15,9 @@ const SOURCE = join(root, 'package.json');
 const TAURI_CONF = join(root, 'src-tauri/tauri.conf.json');
 const CARGO_TOML = join(root, 'src-tauri/Cargo.toml');
 const CARGO_LOCK = join(root, 'src-tauri/Cargo.lock');
+const SHARED_CONSTANTS = join(root, '../shared/lib/constants.ts');
+
+const APP_IDENTIFIER = /APP_IDENTIFIER = '([^']*)'/;
 
 // Anchored so they can only ever match the package's own version, never a
 // dependency's.
@@ -24,6 +27,33 @@ const CARGO_LOCK_VERSION =
 
 const check = process.argv.includes('--check');
 const { version } = JSON.parse(readFileSync(SOURCE, 'utf8'));
+
+// Tauri derives app_data_dir from this identifier, and the CLI derives its
+// global config dir from APP_IDENTIFIER. If the two disagree they silently
+// keep separate global vaults. Never auto-written: changing a shipped
+// identifier moves every installed user's data.
+const expectedIdentifier = readFileSync(
+  SHARED_CONSTANTS,
+  'utf8',
+).match(APP_IDENTIFIER)?.[1];
+
+if (!expectedIdentifier) {
+  console.error(`No APP_IDENTIFIER found in ${SHARED_CONSTANTS}`);
+  process.exit(1);
+}
+
+const { identifier } = JSON.parse(readFileSync(TAURI_CONF, 'utf8'));
+
+if (identifier !== expectedIdentifier) {
+  console.error(
+    `tauri.conf.json identifier "${identifier}" does not match ` +
+      `APP_IDENTIFIER "${expectedIdentifier}".\n` +
+      'The CLI and desktop app would use different global vaults. ' +
+      'Reconcile them by hand — changing a shipped identifier orphans ' +
+      "existing users' app data.",
+  );
+  process.exit(1);
+}
 
 if (!version) {
   console.error('No version field in desktop/package.json');
@@ -41,8 +71,16 @@ const targets = [
       return JSON.stringify(conf, null, 2) + '\n';
     },
   },
-  { path: CARGO_TOML, label: 'Cargo.toml', pattern: CARGO_TOML_VERSION },
-  { path: CARGO_LOCK, label: 'Cargo.lock', pattern: CARGO_LOCK_VERSION },
+  {
+    path: CARGO_TOML,
+    label: 'Cargo.toml',
+    pattern: CARGO_TOML_VERSION,
+  },
+  {
+    path: CARGO_LOCK,
+    label: 'Cargo.lock',
+    pattern: CARGO_LOCK_VERSION,
+  },
 ];
 
 const drifted = [];
@@ -55,7 +93,9 @@ for (const target of targets) {
   if (target.pattern) {
     const match = text.match(target.pattern);
     if (!match) {
-      console.error(`Could not find a version to sync in ${target.label}`);
+      console.error(
+        `Could not find a version to sync in ${target.label}`,
+      );
       process.exit(1);
     }
     current = match[0].slice(match[1].length).replaceAll('"', '');

--- a/shared/db/init.ts
+++ b/shared/db/init.ts
@@ -8,7 +8,19 @@ import { LibSQLDatabase } from 'drizzle-orm/libsql';
 export const initDBConfig = (
   path: string,
   cloudConfig?: CloudVaultConfig,
+  sync: boolean = true,
 ) => {
+  // Without sync there is no replica to seed, so read straight from Turso.
+  // A read-only token can serve that; replication cannot.
+  if (cloudConfig && !sync)
+    return [
+      {
+        url: vaultSyncUrl(cloudConfig.name),
+        authToken: cloudConfig.authToken,
+      },
+      { schema: { secrets: secretsTable } },
+    ] as [Config, DrizzleConfig<{ secrets: typeof secretsTable }>];
+
   const config: Config = {
     url: fileUrl(path),
   };

--- a/shared/tests/mocks/constants.ts
+++ b/shared/tests/mocks/constants.ts
@@ -1,5 +1,13 @@
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
 export const filename = 'sampleSecret.json';
-export const filePath = `./shared/tests/mocks/${filename}`;
+
+// Module-relative: vitest inherits the cwd it was invoked from.
+export const filePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  filename,
+);
 export const fileType = 'application/json';
 export const fileHash =
   '0acb3809d0403bfa58626a36f0f0a64a6a14f302865913a951188d783ae81549';

--- a/skills/deadrop-setup/SKILL.md
+++ b/skills/deadrop-setup/SKILL.md
@@ -26,13 +26,16 @@ asked to protect.
   means it lands in shell history and in this transcript. If a secret is not
   already in a file, stop and ask the user to add it themselves (in Claude
   Code they can run `! deadrop secret add NAME VALUE`).
+- **Never run `deadrop apiKeys create`.** It prints the key to stdout, once —
+  running it here puts a live credential in the transcript and nowhere the
+  user can retrieve it. Tell them to run it themselves.
 - **Verify by name, never by value.** `--verbose` prints variable names only.
 
 If you cannot complete a step without breaking one of these, stop and say so.
 
 `allowed-tools` above deliberately lists individual subcommands rather than
-`deadrop:*`, so `vault export`, `vault sync`, and `secret add` are not
-permitted at all rather than merely discouraged. Keep it that way.
+`deadrop:*`, so `vault export`, `vault sync`, `secret add`, and `apiKeys` are
+not permitted at all rather than merely discouraged. Keep it that way.
 
 ## Scope
 
@@ -166,6 +169,32 @@ deadrop vault env add staging
 deadrop vault drop
 ```
 
-In CI, skip the config file entirely — `DEADROP_API_KEY` plus
-`DEADROP_VAULT_KEY` and `DEADROP_ENVIRONMENT` let `deadrop inject` run with no
-`.deadroprc` at all, minting a short-lived read-only token per job.
+## CI
+
+CI skips the config file entirely. Two variables, nothing else:
+
+```yaml
+env:
+  DEADROP_API_KEY: ${{ secrets.DEADROP_API_KEY }}
+  DEADROP_VAULT_KEY: ${{ secrets.DEADROP_VAULT_KEY }}
+run: deadrop inject --ci -- npm run build
+```
+
+The API key is scoped to one vault and one environment at issue time, so both
+come off its claims — no `.deadroprc`, no `DEADROP_VAULT`, no
+`DEADROP_ENVIRONMENT`. Each run mints its own read-only token that expires in
+five minutes. `--ci` fails immediately naming whichever variable is missing,
+rather than falling back to an interactive sign-in that cannot succeed in a
+container. Needs 1.10.0.
+
+The user issues the key themselves — see the hard rule above:
+
+```
+deadrop apiKeys create -v <vault> -e <environment>
+```
+
+`DEADROP_VAULT_KEY` is that environment's decryption key from `.deadroprc`,
+which you must not read. Have them copy it out.
+
+Secrets reach only the one command `inject` spawns, so each step that needs
+them takes its own `deadrop inject --ci --` wrapper.

--- a/specs/cli-inject-command.md
+++ b/specs/cli-inject-command.md
@@ -7,15 +7,20 @@
   `cli/core.ts`), reusing the config-load + cloud-sync + decrypt path. See
   "Command design" and "Files" below for the current shape — kept in this
   doc as the baseline the rest of it extends.
-- **CI credential minting + `--github-env` — this session's scope.** See
-  "Part A/B/C/D" below. `deadrop inject` today requires a vault config that
-  already has a Turso `authToken` baked in, and only wraps a single spawned
-  command. This session adds: (1) minting a fresh read-only Turso token from
-  just a Clerk API key, so CI never needs a long-lived token stored
-  anywhere; (2) a config-free input path (no `.deadroprc`/`--config` file at
-  all — just env vars); (3) a `--github-env` output mode that persists
-  secrets across an entire CI job instead of wrapping one command; (4) a
-  fix to `cli/install.sh` that would otherwise hang/fail in CI.
+- **CI credential minting — DONE** ([#157](https://github.com/dallen4/deadrop/pull/157)).
+  (1) Minting a fresh read-only Turso token from just a Clerk API key, so CI
+  never needs a long-lived token stored anywhere; (2) a config-free input
+  path (no `.deadroprc`/`--config` file at all — just env vars); (4) the
+  `cli/install.sh` fix that would otherwise hang in CI. Issuance landed too,
+  which this doc never specced: `deadrop apiKeys create` and `POST
+  /auth/key` scope a key to one vault + environment, and `--ci` reads both
+  off its claims, so `DEADROP_VAULT`/`DEADROP_ENVIRONMENT` are unnecessary.
+- **`--github-env` — still open.** Item (3): an output mode that persists
+  secrets across an entire CI job instead of wrapping one command. The
+  design in "`--github-env` semantics" below still stands. `--only` and
+  `--prefix` shipped alongside `--ci` and narrow/rename what a single
+  wrapped command receives, but they do not cross step boundaries — which
+  is what blocks multi-step workflows like `desktop_publish`.
 
 No GitHub Action wrapper is being built as part of this. Docs will show
 users installing `deadrop` directly (existing `install.sh` curl pattern)

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -262,6 +262,7 @@ Run a command with a vault's secrets injected directly into its environment. Sec
 | `--no-override`           | Let pre-existing environment variables win over vault values (default: vault values win).  |
 | `--refresh-token`         | Mint a fresh read-only Turso token before running, instead of reusing a cached one.        |
 | `--ci`                    | Authenticate with a `DEADROP_API_KEY` instead of your signed-in session. See below.        |
+| `--no-sync`               | Read a cloud vault directly instead of replicating it locally. Needed for read-only tokens. |
 | `--only <names>`          | Inject only these secrets, comma-separated. Errors on a name the environment doesn't have. |
 | `--prefix <prefix>`       | Prepend this to every injected variable name, e.g. `--prefix VITE_`.                        |
 | `--verbose`               | Log the names of injected variables. Values are never logged.                              |
@@ -287,6 +288,8 @@ deadrop inject --ci -- pnpm build
 ```
 
 Those two variables are all a pipeline needs. `--ci` fails immediately naming whichever one is missing, rather than falling back to an interactive sign-in that can't succeed in a container. The token it mints is read-only and expires in five minutes.
+
+Pair it with `--no-sync` for a cold read. Building a local replica is itself a write, which a read-only token forbids, so `--no-sync` reads the vault straight over the network instead — there's nothing to keep in sync when the replica is thrown away at the end of the job anyway. The same applies to a vault someone shared with you.
 
 Secrets reach only the command `inject` spawns, so each step that needs them takes its own wrapper. Use `--only` and `--prefix` when one environment serves several jobs — `--only` matches the names as stored, and `--prefix` renames whatever survives the filter:
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -78,7 +78,7 @@ Run the setup wizard once after install:
 deadrop init
 ```
 
-This creates a `.deadroprc` config file in the current directory and your first local vault in a `.deadrop/` folder alongside it — config is scoped per project, so different projects can have different vaults. If a command runs somewhere with no project-scoped config, the CLI falls back to one shared default vault stored in your OS app-data directory — the same one the [desktop app](/docs/features/desktop) uses, so a vault created in either is immediately usable in the other with no import step. The config tracks which vault is active and stores per-vault metadata:
+This creates a `.deadroprc` config file in the current directory and your first local vault in a `.deadrop/` folder alongside it — config is scoped per project, so different projects can have different vaults. If a command runs somewhere with no project-scoped config, the CLI falls back to one shared default vault stored in your OS app-data directory — the same one the [desktop app](/docs/features/desktop) uses, so a vault created in either is immediately usable in the other with no import step. Pass `--global` to set that fallback up directly, or `-y` to accept the defaults without prompting. The config tracks which vault is active and stores per-vault metadata:
 
 <CopyableCode
   value={`active_vault:
@@ -159,7 +159,7 @@ The grabbed secret is printed to stdout, so you can pipe or redirect:
 deadrop grab abc123 > .env.local
 ```
 
-If the drop turns out to be a shared vault (see [`vault drop`](#vault) below), the CLI offers to add it to your config instead of printing it. It writes to the project-scoped `.deadroprc` if there is one, otherwise your global config, and asks which you want when neither exists. Pass `--local` or `--global` to skip that prompt in scripts.
+If the drop turns out to be a shared vault (see [`vault drop`](#vault) below), the CLI offers to add it to your config instead of printing it. It writes to the project-scoped `.deadroprc` if there is one, otherwise your global config, and asks which you want when neither exists.
 
 ### `vault`
 
@@ -261,6 +261,9 @@ Run a command with a vault's secrets injected directly into its environment. Sec
 | `-c, --config <path>`     | Load an explicit config file (JSON or YAML) instead of the auto-discovered config, for CI. |
 | `--no-override`           | Let pre-existing environment variables win over vault values (default: vault values win).  |
 | `--refresh-token`         | Mint a fresh read-only Turso token before running, instead of reusing a cached one.        |
+| `--ci`                    | Authenticate with a `DEADROP_API_KEY` instead of your signed-in session. See below.        |
+| `--only <names>`          | Inject only these secrets, comma-separated. Errors on a name the environment doesn't have. |
+| `--prefix <prefix>`       | Prepend this to every injected variable name, e.g. `--prefix VITE_`.                        |
 | `--verbose`               | Log the names of injected variables. Values are never logged.                              |
 
 The `--` separator is required. Everything after it is passed straight through to your command, so its own flags are safe:
@@ -273,14 +276,50 @@ deadrop inject -- pnpm build --watch   # --watch reaches pnpm, not deadrop
 
 The child process exits with the wrapped command's exit code, and Ctrl-C/SIGTERM are forwarded to it. For cloud vaults, `inject` mints a fresh read-only token on the fly whenever it doesn't already have a usable one, so `deadrop login` isn't strictly required.
 
-**Config-free CI mode.** Set `DEADROP_VAULT_KEY` (the environment's decryption key) and `inject` skips config discovery entirely, so it works from a clean checkout with no `.deadrop/` directory. Select the vault and environment with `DEADROP_VAULT`/`DEADROP_ENVIRONMENT` (or `-v`/`-e`), and authenticate to the token endpoint with `DEADROP_API_KEY` when there's no interactive session:
+**Config-free CI mode.** Set `DEADROP_VAULT_KEY` (the environment's decryption key) and `inject` skips config discovery entirely, so it works from a clean checkout with no `.deadrop/` directory. Select the vault and environment with `DEADROP_VAULT`/`DEADROP_ENVIRONMENT` (or `-v`/`-e`).
+
+With a scoped API key from [`apiKeys create`](#apikeys) you don't need either. Pass `--ci` and the vault and environment both come from the key's own claims:
 
 ```
 DEADROP_API_KEY=... \
 DEADROP_VAULT_KEY=... \
-DEADROP_ENVIRONMENT=production \
-deadrop inject -v prod -- pnpm build
+deadrop inject --ci -- pnpm build
 ```
+
+Those two variables are all a pipeline needs. `--ci` fails immediately naming whichever one is missing, rather than falling back to an interactive sign-in that can't succeed in a container. The token it mints is read-only and expires in five minutes.
+
+Secrets reach only the command `inject` spawns, so each step that needs them takes its own wrapper. Use `--only` and `--prefix` when one environment serves several jobs — `--only` matches the names as stored, and `--prefix` renames whatever survives the filter:
+
+```
+deadrop inject --ci --only API_URL,WEB_URL --prefix VITE_ -- pnpm build
+```
+
+That matters for bundlers: Vite inlines every `VITE_`-prefixed variable present at build time into the client bundle, referenced or not, so `--only` keeps an unrelated secret in the same environment out of what ships.
+
+### `apiKeys`
+
+Issue API keys for CI/CD, scoped to a single cloud vault and environment.
+
+#### `apiKeys create`
+
+Walks you through picking a cloud vault and one of its environments, then shows the key once. Use it as `DEADROP_API_KEY` with [`inject --ci`](#inject).
+
+```
+deadrop apiKeys create
+deadrop apiKeys create -v my-app -e production
+```
+
+| Option                    | Description                                                          |
+| ------------------------- | -------------------------------------------------------------------- |
+| `-v, --vault <name>`      | Cloud vault to scope the key to (prompts to select when omitted).    |
+| `-e, --environment <env>` | Environment to scope the key to (prompts to select when omitted).    |
+| `-y, --yes`               | Skip the confirmation prompt.                                        |
+| `--copy`                  | Copy the key to your clipboard without displaying it.                |
+| `--print`                 | Write the key to stdout so it can be piped.                          |
+
+Only cloud vaults are offered — a key mints sync tokens for a remote database, so a local-only vault has nothing for it to authorize.
+
+The key is shown on a separate screen that leaves nothing in your terminal scrollback once you dismiss it, and it can't be retrieved afterwards. Writing one to a non-interactive stream requires `--print`, so a script can't capture one by accident. List and revoke your keys from your Clerk account settings; each is named with its vault, environment, and issue time.
 
 ### `desktop install`
 

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -72,7 +72,7 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### CI/CD
 
-- **CI service tokens**: `deadrop inject` mints short-lived, read-only vault tokens for non-interactive build pipelines (via `DEADROP_API_KEY` and config-free env vars), replacing the long-lived token in a CI config. Currently gated to early-access accounts.
+- **CI service tokens**: issue a key scoped to one vault and environment with `deadrop apiKeys create`, then `deadrop inject --ci` runs a pipeline step with nothing but that key and the environment's decryption key set. Each run mints its own read-only token that expires in five minutes, replacing the long-lived token in a CI config. Currently gated to early-access accounts.
 
 <DocsSectionTitle
   id={'in-progress'}

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -39,12 +39,14 @@ All keys are exchanged through peer-to-peer connections over WebRTC allowing all
 - ✅ authentication
 - ✅ CLI drop & grab
 - ✅ CLI authentication (OS keychain-backed)
+- ✅ secret injection into any command or CI job (`deadrop inject`)
 - 🧪 local vaults (CLI stable, web experimental)
 - 🧪 cloud-synced vaults (Supporter+ plans)
 - 🧪 VS Code Extension (Supporter+ plans, experimental)
 - 🧪 Desktop app (macOS/Windows/Linux, experimental)
 - 🧪 multidrop: multiple recipients per drop (Supporter+)
 - 🧪 vault sharing: hand a cloud vault to someone else over a drop (read-only, expiring)
+- 🧪 CI/CD service tokens: scoped API keys for pipelines (`deadrop apiKeys create`)
 - ⬜️ drop passcode protection
 - ⬜️ dynamic QR codes
 

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -24,7 +24,7 @@ worker/
 │   │   └── vault.ts          # Vault create/tokens/get/delete/lock/unlock (Turso via @shared/lib/turso)
 │   └── lib/
 │       ├── http/core.ts      # Hono instance + custom context/middleware types
-│       ├── middleware.ts     # cors, tracing, redis, authenticated(), restricted(), service()
+│       ├── middleware.ts     # cors, tracing, redis, authenticated(), restricted(), apiKey(), service()
 │       ├── billing.ts        # getUserPlan/getPlanLimits/hasFeature from Clerk claims
 │       ├── messages.ts       # Message validation helpers
 │       ├── durable_objects/
@@ -49,10 +49,12 @@ worker/
 |--------|------|-------------|
 | GET | `/` | Health check (API metadata) |
 | `*` | `/auth/*` | Clerk auth endpoints |
+| POST | `/auth/key` | Issue a `vault:inject` API key whose claims carry the caller's resolved vault + environment (`authenticated()` + `restricted()`) |
 | `*` | `/peers/*` | PeerJS signaling via `PeerServerDO` — implemented but not live (see top of file); production uses `peers.deadrop.io` on Render |
 | GET/POST/DELETE | `/drop` | Drop session CRUD (Redis) |
 | POST | `/vault` | Create a Turso vault database (`authenticated({ allowApiKey: true })` + `restricted()`) |
 | POST | `/vault/tokens` | Mint a Turso token for a vault — `access` defaults to `read-only`, optional `expiration` (`authenticated({ allowApiKey: true })` + `restricted()`) |
+| POST | `/vault/tokens/ci` | Exchange a `vault:inject` API key for a 5m read-only Turso token — vault and environment come off the key's claims, no request body (`apiKey()` + `restricted()`) |
 | POST | `/vault/rotate` | Invalidate **every** token for a vault — optional `name` in the body, same as `/vault/tokens`, so the default vault stays addressable (`authenticated()` + `restricted()`, deliberately no `allowApiKey`) |
 | GET | `/vault/:name` | Get vault metadata (`authenticated({ allowApiKey: true })`) |
 | DELETE | `/vault/:name` | Delete a vault (`authenticated()` + `restricted()`) |


### PR DESCRIPTION
## Summary

[#157](https://github.com/dallen4/deadrop/pull/157) shipped the CI credential loop but you couldn't run it. There was no way to issue a key from the CLI, and a read-only token couldn't open a vault at all.

**1. Read-only cloud vaults were unusable.** `inject` died with `SQL write operations are forbidden`. Not CI-specific either, anyone who grabbed a shared vault hit it. `initDBClient` ran `CREATE TABLE IF NOT EXISTS` on every connection, and cloud vaults already get that table from Turso, so it's local-only now. Replication counts as a write too, so `--no-sync` reads the vault straight over the network instead of building a replica we throw away at the end of the job.

**2. `deadrop apiKeys create`.** Prompts for a cloud vault and environment, then gives you both values a pipeline needs: the API key and that environment's `DEADROP_VAULT_KEY`. It renders on the alternate screen so nothing lands in scrollback. `--copy` and `--print` cover clipboard and stdout, and a non-interactive stream now requires `--print` so a script can't capture a key by accident.

**3. `--only` and `--prefix` on inject.** `--only NAME,NAME` narrows to a subset and fails on an unknown name instead of injecting nothing. `--prefix VITE_` renames what's left. One `preview`/`prod` environment can now serve jobs that each need a different slice under different names. This also closes a leak: Vite inlines the whole `import.meta.env` object, so every `VITE_` var present at build time ships to browsers whether the code references it or not.

**4. `deadrop init --global`.** Creates the CLI's fallback config, the same one the desktop app writes. Before this you could only get one by running the desktop app or grabbing a shared vault.

**5. Identifier drift guard.** `APP_IDENTIFIER` and `tauri.conf.json`'s `identifier` have to agree or the CLI and desktop quietly use separate global vaults. `sync-version --check` already runs in Desktop CI and now fails on a mismatch.

**6. Also here.** `--debug` and stray `console` routing, the `for...in` signal-handler bug, workspace-dep stripping at publish, the `deadrop-setup` skill, ESLint for `cli/` with type-aware promise rules, a shared API client, a `cwd`-relative test fixture made module-relative, and docs hydrated across all three tiers.

Desktop CI's switch to `inject --ci` landed and got reverted (`c04e48c`). It installs `deadrop` from npm, so it needs this published first. Re-apply after release with `--only`/`--prefix`/`--no-sync`.

Still open: `--github-env` (secrets only reach one child process, which blocks `desktop_publish`), `userOwnsVault` at mint, key expiry, `ci_tokens` quota.

Changesets: `cli` minor (apiKeys create + reveal, `--only`/`--prefix`, `init --global`), `cli` patch (read-only vault fix).

## Test plan
- [x] Full suite: 335 tests / 53 files; typecheck and `pnpm -F cli lint` clean
- [x] New coverage: `initDBClient`'s cloud/local/no-sync modes, `globalConfigDir` on all three platforms, `init --global` against a real temp `HOME`, the `--only`/`--prefix` matrix
- [x] Mutation-tested. Reintroducing each bug fails: schema write, `--global` ignored, wrong macOS path, shaping skipped, missing-name check, identifier drift either way
- [x] Vite full-inline confirmed by build, with an unreferenced `VITE_` canary found in `desktop/dist`
- [ ] **Nothing hit live Clerk or Turso.** It's all mocked at the network boundary, so the below is the real test
- [ ] `deadrop apiKeys create` end to end, key visible in the Clerk account modal
- [ ] `inject --ci --no-sync` in a real pipeline injects the expected count
- [ ] A grabbed read-only shared vault opens with `inject`, the non-CI half of the same fix
- [ ] `deadrop init --global` on a machine with no desktop app installed
