### PR TITLE
desktop vault header + CI reads build config from the vault

### DIFF
--- a/.changeset/desktop-vault-name-header.md
+++ b/.changeset/desktop-vault-name-header.md
@@ -1,0 +1,5 @@
+---
+'desktop': patch
+---
+
+The vault page header is now the vault's name, and clicking it opens the switcher. Previously "Vault" sat as a static heading with a separate dropdown button beside it, which buried the one thing you actually want to see. The switcher marks the active vault, and still holds "New vault" and "Import vault".

--- a/.github/workflows/desktop_ci_workflow.yml
+++ b/.github/workflows/desktop_ci_workflow.yml
@@ -43,16 +43,16 @@ jobs:
       - name: Check desktop version sync
         run: pnpm -F desktop sync-version --check
 
-      # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
+      - name: Install deadrop
+        run: npm install -g deadrop
+
+      # Prod values come from the key's vault env. --no-sync: the CI token
+      # is read-only and replication writes.
       - name: Build desktop frontend
         env:
-          VITE_DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
-          VITE_PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
-          VITE_TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
-          VITE_TURN_PWD: ${{ secrets.TURN_PWD }}
-          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
-          VITE_WEB_URL: ${{ secrets.DEADROP_APP_URL }}
-        run: pnpm -F desktop build
+          DEADROP_API_KEY: ${{ secrets.DEADROP_API_KEY }}
+          DEADROP_VAULT_KEY: ${{ secrets.DEADROP_VAULT_KEY }}
+        run: deadrop inject --ci --no-sync -- pnpm -F desktop build
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -15,14 +15,16 @@ import {
   TextInput,
   Title,
   Tooltip,
+  UnstyledButton,
 } from '@mantine/core';
 import {
   IconAlertCircle,
-  IconChevronDown,
+  IconCheck,
   IconCloud,
   IconCloudOff,
   IconFileImport,
   IconPlus,
+  IconSelector,
   IconShare,
 } from '@tabler/icons-react';
 import { MainWrapper } from '../components/MainWrapper';
@@ -170,43 +172,46 @@ export const VaultPage = () => {
     <MainWrapper>
       <Stack gap={'lg'} w={'100%'}>
         <Group justify={'space-between'}>
-          <Group gap={'sm'}>
-            <Title order={2}>Vault</Title>
-            <Menu>
-              <Menu.Target>
-                <Button
-                  size={'xs'}
-                  variant={'light'}
-                  rightSection={<IconChevronDown size={14} />}
-                >
-                  {vault.activeVaultName}
-                </Button>
-              </Menu.Target>
-              <Menu.Dropdown>
-                {vaultNames.map((name) => (
-                  <Menu.Item
-                    key={name}
-                    onClick={() => vault.switchVault(name)}
-                  >
-                    {name}
-                  </Menu.Item>
-                ))}
-                <Menu.Divider />
+          <Menu position={'bottom-start'} width={220}>
+            <Menu.Target>
+              <UnstyledButton aria-label={'Switch vault'}>
+                <Group gap={6} wrap={'nowrap'}>
+                  <Title order={2}>{vault.activeVaultName}</Title>
+                  <IconSelector size={20} stroke={1.5} />
+                </Group>
+              </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {vaultNames.map((name) => (
                 <Menu.Item
-                  leftSection={<IconPlus size={14} />}
-                  onClick={() => setCreateModalOpen(true)}
+                  key={name}
+                  onClick={() => vault.switchVault(name)}
+                  // The name is the heading now, so the dropdown is the
+                  // only place the active vault is marked.
+                  rightSection={
+                    name === vault.activeVaultName ? (
+                      <IconCheck size={14} />
+                    ) : undefined
+                  }
                 >
-                  New vault
+                  {name}
                 </Menu.Item>
-                <Menu.Item
-                  leftSection={<IconFileImport size={14} />}
-                  onClick={() => void vault.importVault()}
-                >
-                  Import vault
-                </Menu.Item>
-              </Menu.Dropdown>
-            </Menu>
-          </Group>
+              ))}
+              <Menu.Divider />
+              <Menu.Item
+                leftSection={<IconPlus size={14} />}
+                onClick={() => setCreateModalOpen(true)}
+              >
+                New vault
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<IconFileImport size={14} />}
+                onClick={() => void vault.importVault()}
+              >
+                Import vault
+              </Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
 
           <Group gap={'sm'}>
             {canShare && (

--- a/worker/src/lib/middleware.ts
+++ b/worker/src/lib/middleware.ts
@@ -1,7 +1,4 @@
-import {
-  TokenType,
-  SignedInAuthObject,
-} from '@clerk/backend/internal';
+import { TokenType } from '@clerk/backend/internal';
 import { getAuth } from '@clerk/hono';
 import { SERVICE_TOKEN_HEADER } from '@shared/lib/constants';
 import { TEST_TOKEN_HEADER } from '@shared/tests/http';

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -1,4 +1,3 @@
-import z from 'zod';
 import { AppRouteParts, AuthScopes } from '../constants';
 import { hono } from '../lib/http/core';
 import { authenticated, restricted } from '../lib/middleware';


### PR DESCRIPTION
## Summary

Two things, and a patch release to prove the desktop publish path still works end to end.

**1. Vault page header.** The header is the vault's name now, and clicking it opens the switcher. Before this "Vault" sat as a static heading with a separate dropdown button next to it, which buried the one thing you actually want to see. The switcher marks the active vault, since the name is no longer repeated on a button, and still holds "New vault" and "Import vault".

**2. Desktop CI reads from the vault.** `deadrop inject --ci --no-sync` replaces the six `VITE_*` secrets in the build step, so the job carries `DEADROP_API_KEY` and `DEADROP_VAULT_KEY` and nothing else. Already verified green on a real run: `Injecting 6 secret(s) from '32e9cd8931077-deadrop' (desktop)`. That run was also the first time the read-only fixes from #159 touched live Clerk and Turso rather than mocks.

Also drops two imports that went unused in #159 (`z` in `auth.ts`, `SignedInAuthObject` in `middleware.ts`), so the worker typechecks clean.

Changesets: `desktop` patch.

## Test plan
- [x] Full suite: 335 tests / 53 files; worker typecheck and `pnpm -F cli lint` clean
- [x] `pnpm -F desktop build` compiles the new header
- [x] Desktop CI green on `alpha` with the vault-backed build step
- [ ] Header feels right in a real window: name reads as the heading, chevron is discoverable, switcher opens on click
- [ ] Release path: version PR bumps `desktop`, `sync-version` propagates to `tauri.conf.json` + Cargo files, and the identifier drift check added in `7a10238` runs during a release for the first time
- [ ] `deadrop-desktop@0.3.2` tag dispatches `desktop_publish_workflow.yml` and the bundles publish
