### PR TITLE
vault sidebar layout + --ci implies no sync

### DIFF
--- a/.changeset/cli-ci-implies-no-sync.md
+++ b/.changeset/cli-ci-implies-no-sync.md
@@ -1,0 +1,5 @@
+---
+'cli': patch
+---
+
+`deadrop inject --ci` no longer needs `--no-sync`. A CI key mints a read-only token against a replica that gets thrown away at the end of the job, so there is nothing to replicate into and no permission to do it. Passing `--no-sync` alongside `--ci` still works and changes nothing.

--- a/.changeset/desktop-vault-sidebar.md
+++ b/.changeset/desktop-vault-sidebar.md
@@ -1,0 +1,5 @@
+---
+'desktop': patch
+---
+
+The vault page splits into a sidebar and a content pane. Environments and Credentials move to a left rail, and the environment tabs, secrets and credential controls render beside it instead of stacking underneath.

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -262,14 +262,14 @@ export async function inject(
     process.exit(1);
   }
 
-  const { vaultName, environment, vault, ephemeral } =
+  const { vaultName, environment, vault, ephemeral, strategy } =
     await parseVaultFromOptions(options);
 
-  const db = await initDBClient(
-    vault.location,
-    vault.cloud,
-    options.sync,
-  );
+  // CI tokens are read-only, and the replica is discarded anyway.
+  const sync =
+    strategy !== MintStrategy.ApiKey && options.sync !== false;
+
+  const db = await initDBClient(vault.location, vault.cloud, sync);
 
   const { getAllSecrets } = createSecretsHelpers(vault, db);
 

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -285,7 +285,7 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith(
       './vault.db',
       { name: 'a1b2c3d4e5f67-default', authToken: 'minted-token' },
-      undefined,
+      true,
     );
     expect(runWithEnvSpy).toHaveBeenCalledWith(
       'node',
@@ -343,7 +343,7 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith(
       './vault.db',
       cloud,
-      undefined,
+      true,
     );
   });
 
@@ -381,7 +381,7 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith(
       './vault.db',
       undefined,
-      undefined,
+      true,
     );
   });
 
@@ -435,7 +435,7 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith(
       './vault.db',
       { name: 'a1b2c3d4e5f67-default', authToken: 'refreshed-token' },
-      undefined,
+      true,
     );
   });
 
@@ -626,8 +626,9 @@ describe('inject', () => {
     expect(mintVaultToken).not.toHaveBeenCalled();
     expect(initDBClient).toHaveBeenCalledWith(
       expect.stringContaining('deadrop-inject-'),
+      // --ci is always a cold read, so it never replicates.
       { name: 'a1b2c3d4e5f67-my-app', authToken: 'ci-token' },
-      undefined,
+      false,
     );
     expect(
       vi.mocked(createSecretsHelpers).mock.calls[0][0],

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -23,9 +23,11 @@ import {
   IconCloud,
   IconCloudOff,
   IconFileImport,
+  IconKey,
   IconPlus,
   IconSelector,
   IconShare,
+  IconStack2,
 } from '@tabler/icons-react';
 import { MainWrapper } from '../components/MainWrapper';
 import { useVault } from '../hooks/use-vault';
@@ -265,13 +267,34 @@ export const VaultPage = () => {
           </Alert>
         )}
 
-        <Tabs defaultValue={'secrets'}>
-          <Tabs.List mb={'md'}>
-            <Tabs.Tab value={'secrets'}>Secrets</Tabs.Tab>
-            <Tabs.Tab value={'credentials'}>Credentials</Tabs.Tab>
+        <Tabs
+          defaultValue={'environments'}
+          orientation={'vertical'}
+          variant={'pills'}
+        >
+          <Tabs.List
+            w={190}
+            pr={'md'}
+            style={{
+              borderRight:
+                '1px solid var(--mantine-color-default-border)',
+            }}
+          >
+            <Tabs.Tab
+              value={'environments'}
+              leftSection={<IconStack2 size={16} />}
+            >
+              Environments
+            </Tabs.Tab>
+            <Tabs.Tab
+              value={'credentials'}
+              leftSection={<IconKey size={16} />}
+            >
+              Credentials
+            </Tabs.Tab>
           </Tabs.List>
 
-          <Tabs.Panel value={'secrets'}>
+          <Tabs.Panel value={'environments'} pl={'lg'}>
             <Stack gap={'lg'}>
               <Tabs
                 value={vault.activeEnv}
@@ -325,7 +348,7 @@ export const VaultPage = () => {
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value={'credentials'}>
+          <Tabs.Panel value={'credentials'} pl={'lg'}>
             <CredentialsTab
               vaultName={vault.activeVaultName}
               cloudName={vault.activeVault?.cloud?.name}


### PR DESCRIPTION
## Summary

- Vault page splits into a sidebar and a content pane. Environments and Credentials sit in a left rail, and the environment tabs, secrets and credential controls render beside it instead of stacking underneath.
- `deadrop inject --ci` no longer needs `--no-sync`. A CI key mints a read-only token against a replica we throw away, so there is nothing to replicate into and no permission to do it. Passing `--no-sync` with `--ci` still works and changes nothing.

Changesets: `cli` patch, `desktop` patch.

Once 1.11.1 publishes, `--no-sync` can come out of `desktop_ci_workflow.yml`. Leaving it in until then, since CI installs `deadrop` from npm and 1.11.0 still needs it.

## Test plan
- [x] 335 tests / 53 files; CLI typecheck clean; `pnpm -F desktop build` compiles
- [ ] Sidebar layout in a real window. It builds and typechecks, but nobody has looked at it
- [ ] `deadrop inject --ci` with no `--no-sync` against a read-only vault, after 1.11.1 lands
