### PR TITLE
desktop vault api keys + /auth/keys collection

### DIFF
--- a/.changeset/desktop-vault-api-keys.md
+++ b/.changeset/desktop-vault-api-keys.md
@@ -1,0 +1,10 @@
+---
+'desktop': minor
+'shared': minor
+---
+
+Manage CI service tokens from the desktop app. Each environment in a cloud vault you own now splits into Secrets and API Keys sections: the API Keys section lists the keys already scoped to that vault and environment with their active, expired, or revoked state, and issues new ones without dropping to the CLI. A new key is shown once when it is created, since that is the only time it can be read back. A local vault, or a cloud vault shared with you, keeps the plain secrets list it had before, because neither has keys to manage.
+
+Adding a secret moved into a dialog behind an "Add secret" row rather than a form sitting open at the bottom of the list, and both dialogs name the vault and environment being written to so a secret cannot be added to the wrong environment by accident.
+
+`shared` gains the `AuthScopes` enum, previously worker-only, so any surface can name the scope it is filtering keys on.

--- a/.changeset/vault-api-keys-collection.md
+++ b/.changeset/vault-api-keys-collection.md
@@ -1,0 +1,8 @@
+---
+'worker': minor
+'cli': patch
+---
+
+API keys move from `POST /auth/key` to an `/auth/keys` collection that serves both issuance and listing. `GET /auth/keys` returns the caller's `vault:inject` keys for a vault and environment, filtered by scope and by the claims the key was minted with, and returns only each key's id, name, and expired/revoked state. It resolves the vault name the same way issuance does, so a caller passes the local vault name it already knows and never has to construct the hashed cloud name itself.
+
+`deadrop apiKeys create` follows the route to its new path. The old `/auth/key` path is gone, so a CLI older than this release cannot create keys once the worker deploys.

--- a/.changeset/worker-per-user-drop-count.md
+++ b/.changeset/worker-per-user-drop-count.md
@@ -1,0 +1,5 @@
+---
+'worker': patch
+---
+
+Signed-in droppers count against their own account rather than their IP address. Previously everyone behind one address shared a single daily allowance, so colleagues on an office network or a VPN could exhaust each other's drops. Anonymous drops are still counted per IP.

--- a/.github/workflows/web_ci_workflow.yml
+++ b/.github/workflows/web_ci_workflow.yml
@@ -46,17 +46,6 @@ jobs:
           export STAGE=$STAGE
           echo "Running '$STAGE' environment tests..."
 
-          export DEADROP_API_URL=$DEADROP_API_URL
-          echo $DEADROP_API_URL
-
-          export REDIS_REST_URL=$REDIS_REST_URL
-          export REDIS_REST_TOKEN=$REDIS_REST_TOKEN
-          export STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY
-          export STRIPE_WEBHOOK_SECRET=$STRIPE_WEBHOOK_SECRET
-          export STRIPE_SUPPORTER_LOOKUP_KEY=$STRIPE_SUPPORTER_LOOKUP_KEY
-          export CLERK_WEBHOOK_SIGNING_SECRET=$CLERK_WEBHOOK_SIGNING_SECRET
-          export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-
           # Vercel deployments carry only the commit SHA, so resolve which
           # branch that commit is the head of to choose the test domain.
           # Payment/Clerk specs (RUN_AUTH_TESTS) run on Preview (alpha) ONLY:
@@ -89,7 +78,10 @@ jobs:
           fi
 
           echo "TEST_URI=$TEST_URI  RUN_AUTH_TESTS=${RUN_AUTH_TESTS:-0}"
-          CI=true pnpm test:e2e --trace on
+
+          export CI=true
+
+          pnpm test:e2e --trace on
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/cli/actions/apiKeys.ts
+++ b/cli/actions/apiKeys.ts
@@ -174,7 +174,7 @@ export async function createApiKey(
   }
 
   try {
-    const response = await deadropClient.auth.key.$post({
+    const response = await deadropClient.auth.keys.$post({
       json: { vaultName, environment },
     });
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -72,7 +72,11 @@ vault" (`src/lib/vault-config.ts`'s `pickExternalVaultConfig`). Any imported
 or grabbed cloud vault gets a fresh replica path (`resolveImportedVault`) —
 the incoming `location` is the sender's, and means nothing here.
 
-`Vault.tsx` splits into Secrets and Credentials tabs. Credentials
+`Vault.tsx` splits into Environments and Credentials panes. Environments
+holds the per-environment tabs; for a cloud vault you own it sections into
+Secrets and API Keys accordions (`ApiKeysSection.tsx`, backed by
+`src/lib/auth.ts`'s `useApiKeys` against `GET`/`POST /auth/keys`), while a
+local vault or one shared with you keeps the flat secrets list. Credentials
 (`src/components/vault/CredentialsTab.tsx`) issues sync tokens with an
 access level + expiry and offers a break-glass rotate, both owner-gated on
 `userOwnsVault` — a vault you don't own can't be reminted, so its stored

--- a/desktop/src/components/vault/AddRowButton.tsx
+++ b/desktop/src/components/vault/AddRowButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+
+export const AddRowButton = ({
+  label,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) => (
+  <Button
+    fullWidth
+    mt={'xs'}
+    size={'sm'}
+    variant={'outline'}
+    color={'blue.4'}
+    opacity={0.7}
+    leftSection={<IconPlus size={14} />}
+    disabled={disabled}
+    onClick={onClick}
+  >
+    {label}
+  </Button>
+);

--- a/desktop/src/components/vault/AddSecretForm.tsx
+++ b/desktop/src/components/vault/AddSecretForm.tsx
@@ -1,30 +1,14 @@
 import { useState } from 'react';
 import {
   Button,
-  Code,
   Divider,
   Group,
   Modal,
   Stack,
-  Text,
   TextInput,
 } from '@mantine/core';
 import { AddRowButton } from './AddRowButton';
-
-const Detail = ({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) => (
-  <Stack gap={2}>
-    <Text size={'xs'} c={'dimmed'} tt={'uppercase'}>
-      {label}
-    </Text>
-    {children}
-  </Stack>
-);
+import { TargetDetails } from './TargetDetails';
 
 export const AddSecretForm = ({
   disabled,
@@ -68,19 +52,11 @@ export const AddSecretForm = ({
         title={'New secret'}
       >
         <Stack gap={'md'}>
-          <Group gap={'xl'} align={'flex-start'}>
-            <Detail label={'Vault'}>
-              <Text size={'sm'} fw={500}>
-                {vaultName}
-              </Text>
-              {cloudName && <Code>{cloudName}</Code>}
-            </Detail>
-            <Detail label={'Environment'}>
-              <Text size={'sm'} fw={500}>
-                {environment}
-              </Text>
-            </Detail>
-          </Group>
+          <TargetDetails
+            vaultName={vaultName}
+            cloudName={cloudName}
+            environment={environment}
+          />
 
           <Divider />
 

--- a/desktop/src/components/vault/AddSecretForm.tsx
+++ b/desktop/src/components/vault/AddSecretForm.tsx
@@ -1,13 +1,42 @@
 import { useState } from 'react';
-import { Button, Group, TextInput } from '@mantine/core';
-import { IconPlus } from '@tabler/icons-react';
+import {
+  Button,
+  Code,
+  Divider,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
 import { AddRowButton } from './AddRowButton';
+
+const Detail = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Stack gap={2}>
+    <Text size={'xs'} c={'dimmed'} tt={'uppercase'}>
+      {label}
+    </Text>
+    {children}
+  </Stack>
+);
 
 export const AddSecretForm = ({
   disabled,
+  vaultName,
+  cloudName,
+  environment,
   onSubmit,
 }: {
   disabled: boolean;
+  vaultName: string;
+  cloudName?: string;
+  environment: string;
   onSubmit: (name: string, value: string) => Promise<void>;
 }) => {
   const [open, setOpen] = useState(false);
@@ -26,58 +55,67 @@ export const AddSecretForm = ({
     close();
   };
 
-  if (!open) {
-    return (
+  return (
+    <>
       <AddRowButton
         label={'Add secret'}
         onClick={() => setOpen(true)}
       />
-    );
-  }
+      <Modal
+        centered
+        opened={open}
+        onClose={close}
+        title={'New secret'}
+      >
+        <Stack gap={'md'}>
+          <Group gap={'xl'} align={'flex-start'}>
+            <Detail label={'Vault'}>
+              <Text size={'sm'} fw={500}>
+                {vaultName}
+              </Text>
+              {cloudName && <Code>{cloudName}</Code>}
+            </Detail>
+            <Detail label={'Environment'}>
+              <Text size={'sm'} fw={500}>
+                {environment}
+              </Text>
+            </Detail>
+          </Group>
 
-  return (
-    <Group gap={'xs'} mt={'md'} align={'flex-end'}>
-      <TextInput
-        label={'Name'}
-        placeholder={'API_KEY'}
-        size={'sm'}
-        value={name}
-        autoFocus
-        onChange={(e) => setName(e.currentTarget.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') void handleSubmit();
-          if (e.key === 'Escape') close();
-        }}
-        style={{ flex: 1 }}
-      />
-      <TextInput
-        label={'Value'}
-        placeholder={'secret value'}
-        size={'sm'}
-        value={value}
-        onChange={(e) => setValue(e.currentTarget.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') void handleSubmit();
-          if (e.key === 'Escape') close();
-        }}
-        style={{ flex: 1 }}
-      />
-      <Button
-        size={'sm'}
-        leftSection={<IconPlus size={14} />}
-        loading={disabled}
-        onClick={() => void handleSubmit()}
-      >
-        Add
-      </Button>
-      <Button
-        size={'sm'}
-        variant={'subtle'}
-        color={'gray'}
-        onClick={close}
-      >
-        Cancel
-      </Button>
-    </Group>
+          <Divider />
+
+          <TextInput
+            label={'Name'}
+            placeholder={'API_KEY'}
+            value={name}
+            autoFocus
+            onChange={(e) => setName(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleSubmit();
+            }}
+          />
+          <TextInput
+            label={'Value'}
+            placeholder={'secret value'}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleSubmit();
+            }}
+          />
+          <Group justify={'flex-end'}>
+            <Button variant={'subtle'} onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              loading={disabled}
+              onClick={() => void handleSubmit()}
+            >
+              Add
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
   );
 };

--- a/desktop/src/components/vault/AddSecretForm.tsx
+++ b/desktop/src/components/vault/AddSecretForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button, Group, TextInput } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
+import { AddRowButton } from './AddRowButton';
 
 export const AddSecretForm = ({
   disabled,
@@ -9,15 +10,30 @@ export const AddSecretForm = ({
   disabled: boolean;
   onSubmit: (name: string, value: string) => Promise<void>;
 }) => {
+  const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const [value, setValue] = useState('');
+
+  const close = () => {
+    setOpen(false);
+    setName('');
+    setValue('');
+  };
 
   const handleSubmit = async () => {
     if (!name.trim() || !value) return;
     await onSubmit(name.trim(), value);
-    setName('');
-    setValue('');
+    close();
   };
+
+  if (!open) {
+    return (
+      <AddRowButton
+        label={'Add secret'}
+        onClick={() => setOpen(true)}
+      />
+    );
+  }
 
   return (
     <Group gap={'xs'} mt={'md'} align={'flex-end'}>
@@ -26,7 +42,12 @@ export const AddSecretForm = ({
         placeholder={'API_KEY'}
         size={'sm'}
         value={name}
+        autoFocus
         onChange={(e) => setName(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') void handleSubmit();
+          if (e.key === 'Escape') close();
+        }}
         style={{ flex: 1 }}
       />
       <TextInput
@@ -35,6 +56,10 @@ export const AddSecretForm = ({
         size={'sm'}
         value={value}
         onChange={(e) => setValue(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') void handleSubmit();
+          if (e.key === 'Escape') close();
+        }}
         style={{ flex: 1 }}
       />
       <Button
@@ -44,6 +69,14 @@ export const AddSecretForm = ({
         onClick={() => void handleSubmit()}
       >
         Add
+      </Button>
+      <Button
+        size={'sm'}
+        variant={'subtle'}
+        color={'gray'}
+        onClick={close}
+      >
+        Cancel
       </Button>
     </Group>
   );

--- a/desktop/src/components/vault/ApiKeysSection.tsx
+++ b/desktop/src/components/vault/ApiKeysSection.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Badge,
+  Button,
+  Code,
+  CopyButton,
+  Divider,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+} from '@mantine/core';
+import {
+  IconAlertCircle,
+  IconCheck,
+  IconCopy,
+} from '@tabler/icons-react';
+import { useApiKeys } from '../../lib/auth';
+import { AddRowButton } from './AddRowButton';
+import { TargetDetails } from './TargetDetails';
+
+type ApiKeySummary = {
+  id: string;
+  name: string;
+  expired: boolean;
+  revoked: boolean;
+};
+
+type IssuedKey = { id: string; name: string; key: string };
+
+const StatusBadge = ({ expired, revoked }: ApiKeySummary) => {
+  if (revoked)
+    return (
+      <Badge size={'sm'} color={'red'} variant={'light'}>
+        Revoked
+      </Badge>
+    );
+
+  if (expired)
+    return (
+      <Badge size={'sm'} color={'gray'} variant={'light'}>
+        Expired
+      </Badge>
+    );
+
+  return (
+    <Badge size={'sm'} color={'teal'} variant={'light'}>
+      Active
+    </Badge>
+  );
+};
+
+export const ApiKeysSection = ({
+  vaultName,
+  cloudName,
+  environment,
+}: {
+  vaultName: string;
+  cloudName?: string;
+  environment: string;
+}) => {
+  const { listApiKeys, createApiKey } = useApiKeys();
+
+  const [keys, setKeys] = useState<ApiKeySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [issuing, setIssuing] = useState(false);
+  const [issued, setIssued] = useState<IssuedKey | null>(null);
+  const [issueError, setIssueError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let stale = false;
+
+    setLoading(true);
+    setError(null);
+
+    listApiKeys({ vaultName, environment })
+      .then((loaded) => {
+        if (!stale) setKeys(loaded);
+      })
+      .catch((err: Error) => {
+        if (!stale) setError(err.message);
+      })
+      .finally(() => {
+        if (!stale) setLoading(false);
+      });
+
+    return () => {
+      stale = true;
+    };
+    // The hook's callbacks are recreated per render, so the vault
+    // target is what actually decides when to refetch.
+  }, [vaultName, environment]);
+
+  const issue = async () => {
+    setIssuing(true);
+    setIssueError(null);
+    try {
+      const key = await createApiKey({ vaultName, environment });
+      setIssued(key);
+      setKeys(await listApiKeys({ vaultName, environment }));
+    } catch (err) {
+      setIssueError((err as Error).message);
+    } finally {
+      setIssuing(false);
+    }
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setIssued(null);
+    setIssueError(null);
+  };
+
+  return (
+    <>
+      {loading ? (
+        <Group gap={'xs'} py={4}>
+          <Loader size={'xs'} />
+          <Text size={'sm'} c={'dimmed'}>
+            Loading API keys…
+          </Text>
+        </Group>
+      ) : error ? (
+        <Alert color={'red'} icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      ) : (
+        <Stack gap={4}>
+          {keys.length === 0 ? (
+            <Text size={'sm'} c={'dimmed'}>
+              No API keys yet for <b>{environment}</b>.
+            </Text>
+          ) : (
+            keys.map((key) => (
+              <Group
+                key={key.id}
+                justify={'space-between'}
+                py={4}
+                wrap={'nowrap'}
+              >
+                <Text
+                  size={'sm'}
+                  ff={'monospace'}
+                  style={{ flex: 1, minWidth: 0 }}
+                  truncate
+                >
+                  {key.name}
+                </Text>
+                <StatusBadge {...key} />
+              </Group>
+            ))
+          )}
+        </Stack>
+      )}
+
+      <AddRowButton
+        label={'Add API key'}
+        onClick={() => setModalOpen(true)}
+      />
+
+      <Modal
+        centered
+        opened={modalOpen}
+        onClose={closeModal}
+        title={issued ? 'API key created' : 'New API key'}
+      >
+        <Stack gap={'md'}>
+          <TargetDetails
+            vaultName={vaultName}
+            cloudName={cloudName}
+            environment={environment}
+          />
+
+          <Divider />
+
+          {issued ? (
+            <>
+              <Text size={'sm'}>
+                Copy <Code>{issued.name}</Code> now — this is the only
+                time the key is shown.
+              </Text>
+              <Code block style={{ wordBreak: 'break-all' }}>
+                {issued.key}
+              </Code>
+              <Group justify={'flex-end'}>
+                <CopyButton value={issued.key}>
+                  {({ copied, copy }) => (
+                    <Button
+                      variant={'default'}
+                      color={copied ? 'teal' : undefined}
+                      leftSection={
+                        copied ? (
+                          <IconCheck size={14} />
+                        ) : (
+                          <IconCopy size={14} />
+                        )
+                      }
+                      onClick={copy}
+                    >
+                      {copied ? 'Copied' : 'Copy'}
+                    </Button>
+                  )}
+                </CopyButton>
+                <Button onClick={closeModal}>Done</Button>
+              </Group>
+            </>
+          ) : (
+            <>
+              <Text size={'sm'} c={'dimmed'}>
+                Mints a key scoped to this vault and environment, for
+                injecting secrets into CI/CD.
+              </Text>
+              {issueError && (
+                <Alert
+                  color={'red'}
+                  icon={<IconAlertCircle size={16} />}
+                >
+                  {issueError}
+                </Alert>
+              )}
+              <Group justify={'flex-end'}>
+                <Button variant={'subtle'} onClick={closeModal}>
+                  Cancel
+                </Button>
+                <Button
+                  loading={issuing}
+                  onClick={() => void issue()}
+                >
+                  Create
+                </Button>
+              </Group>
+            </>
+          )}
+        </Stack>
+      </Modal>
+    </>
+  );
+};

--- a/desktop/src/components/vault/TargetDetails.tsx
+++ b/desktop/src/components/vault/TargetDetails.tsx
@@ -1,0 +1,40 @@
+import { Code, Group, Stack, Text } from '@mantine/core';
+
+const Detail = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Stack gap={2}>
+    <Text size={'xs'} c={'dimmed'} tt={'uppercase'}>
+      {label}
+    </Text>
+    {children}
+  </Stack>
+);
+
+export const TargetDetails = ({
+  vaultName,
+  cloudName,
+  environment,
+}: {
+  vaultName: string;
+  cloudName?: string;
+  environment: string;
+}) => (
+  <Group gap={'xl'} align={'flex-start'}>
+    <Detail label={'Vault'}>
+      <Text size={'sm'} fw={500}>
+        {vaultName}
+      </Text>
+      {cloudName && <Code>{cloudName}</Code>}
+    </Detail>
+    <Detail label={'Environment'}>
+      <Text size={'sm'} fw={500}>
+        {environment}
+      </Text>
+    </Detail>
+  </Group>
+);

--- a/desktop/src/lib/auth.ts
+++ b/desktop/src/lib/auth.ts
@@ -1,49 +1,61 @@
-import { createClient, DeadropApiClient } from '@shared/client';
+import { createClient } from '@shared/client';
 import { useApiHeaders } from './api-headers';
-import { DEADROP_API_URL } from 'src/env';
+import { DEADROP_API_URL } from '../env';
 import { AuthScopes } from '@shared/lib/constants';
-import { useRef } from 'react';
+import { useCallback } from 'react';
 
-export async function useApiKeys() {
+export type VaultApiKeyTarget = {
+  vaultName: string;
+  environment: string;
+};
+
+export const useApiKeys = () => {
   const getApiHeaders = useApiHeaders();
-  const clientRef = useRef<DeadropApiClient>(null);
 
-  const initClient = async () => {
-    if (clientRef.current) return clientRef.current;
+  // Clerk session tokens are short-lived, so headers are resolved per
+  // call rather than baked into a cached client.
+  const initClient = useCallback(
+    async () =>
+      createClient(DEADROP_API_URL, {
+        init: { headers: await getApiHeaders() },
+      }),
+    [getApiHeaders],
+  );
 
-    return (clientRef.current = createClient(DEADROP_API_URL, {
-      init: { headers: await getApiHeaders() },
-    }));
-  };
+  const listApiKeys = useCallback(
+    async (target: VaultApiKeyTarget) => {
+      const client = await initClient();
 
-  const listApiKeys = async (claims: {
-    vaultName: string;
-    environment: string;
-  }) => {
-    const client = await initClient();
+      const response = await client.auth.keys.$get({
+        query: {
+          scopes: [AuthScopes.VaultInject],
+          ...target,
+        },
+      });
 
-    const listApiKeysResponse = await client.auth.keys.$get({
-      query: {
-        scopes: [AuthScopes.VaultInject],
-        ...claims,
-      },
-    });
+      if (!response.ok)
+        throw new Error('Could not load API keys for this vault.');
 
-    return listApiKeysResponse.json();
-  };
+      return response.json();
+    },
+    [initClient],
+  );
 
-  const createApiKey = async (claims: {
-    vaultName: string;
-    environment: string;
-  }) => {
-    const client = await initClient();
+  const createApiKey = useCallback(
+    async (target: VaultApiKeyTarget) => {
+      const client = await initClient();
 
-    const apiKeysResponse = await client.auth.keys.$post({
-      json: claims,
-    });
+      const response = await client.auth.keys.$post({
+        json: target,
+      });
 
-    return apiKeysResponse.json();
-  };
+      if (response.status !== 201)
+        throw new Error('Could not issue an API key for this vault.');
+
+      return response.json();
+    },
+    [initClient],
+  );
 
   return { listApiKeys, createApiKey };
-}
+};

--- a/desktop/src/lib/auth.ts
+++ b/desktop/src/lib/auth.ts
@@ -1,0 +1,49 @@
+import { createClient, DeadropApiClient } from '@shared/client';
+import { useApiHeaders } from './api-headers';
+import { DEADROP_API_URL } from 'src/env';
+import { AuthScopes } from '@shared/lib/constants';
+import { useRef } from 'react';
+
+export async function useApiKeys() {
+  const getApiHeaders = useApiHeaders();
+  const clientRef = useRef<DeadropApiClient>(null);
+
+  const initClient = async () => {
+    if (clientRef.current) return clientRef.current;
+
+    return (clientRef.current = createClient(DEADROP_API_URL, {
+      init: { headers: await getApiHeaders() },
+    }));
+  };
+
+  const listApiKeys = async (claims: {
+    vaultName: string;
+    environment: string;
+  }) => {
+    const client = await initClient();
+
+    const listApiKeysResponse = await client.auth.keys.$get({
+      query: {
+        scopes: [AuthScopes.VaultInject],
+        ...claims,
+      },
+    });
+
+    return listApiKeysResponse.json();
+  };
+
+  const createApiKey = async (claims: {
+    vaultName: string;
+    environment: string;
+  }) => {
+    const client = await initClient();
+
+    const apiKeysResponse = await client.auth.keys.$post({
+      json: claims,
+    });
+
+    return apiKeysResponse.json();
+  };
+
+  return { listApiKeys, createApiKey };
+}

--- a/desktop/src/routes/Vault.module.css
+++ b/desktop/src/routes/Vault.module.css
@@ -1,0 +1,14 @@
+/* Mantine's `unset` var defaults are inherited, so the outer vertical Tabs' values leak in and box the line. */
+.envTabs {
+  --tabs-list-line-top: auto;
+  --tabs-list-gap: 0;
+}
+
+/* Doubled to outrank Mantine's own equal-specificity `.control:hover`. */
+.sectionControl.sectionControl {
+  padding: 0 var(--mantine-spacing-xs);
+}
+
+.sectionControl.sectionControl:hover {
+  background-color: transparent;
+}

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -216,6 +216,9 @@ export const VaultPage = () => {
       ) : (
         <AddSecretForm
           disabled={vault.busy}
+          vaultName={vault.activeVaultName}
+          cloudName={vault.activeVault?.cloud?.name}
+          environment={vault.activeEnv}
           onSubmit={vault.addSecret}
         />
       )}

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -33,7 +33,9 @@ import {
   IconStack2,
 } from '@tabler/icons-react';
 import { MainWrapper } from '../components/MainWrapper';
+import classes from './Vault.module.css';
 import { useVault } from '../hooks/use-vault';
+import { AddRowButton } from '../components/vault/AddRowButton';
 import { AddSecretForm } from '../components/vault/AddSecretForm';
 import { CreateVaultModal } from '../components/vault/CreateVaultModal';
 import { CredentialsTab } from '../components/vault/CredentialsTab';
@@ -105,10 +107,11 @@ export const VaultPage = () => {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
 
-  // Only the owner can mint the read-only token a share carries.
-  const canShare = vault.cloudSync && vault.ownsActiveCloudVault;
+  // Only the owner can mint the read-only token a share carries, and
+  // only an owned cloud vault has API keys to section off.
+  const owned = vault.cloudSync && vault.ownsActiveCloudVault;
 
-  // Not !canShare — a local vault has no owner and stays writable.
+  // Not !owned — a local vault has no owner and stays writable.
   const readOnly = vault.cloudSync && !vault.ownsActiveCloudVault;
 
   const shareVault = async (envs: string[], expiration: string) => {
@@ -183,6 +186,42 @@ export const VaultPage = () => {
     (s) => s.environment === vault.activeEnv,
   );
 
+  const secretsSection = (
+    <>
+      <Stack gap={4}>
+        {filtered.length === 0 ? (
+          <Text size={'sm'} c={'dimmed'}>
+            No secrets yet for <b>{vault.activeEnv}</b>.
+          </Text>
+        ) : (
+          filtered.map((s) => (
+            <SecretRow
+              key={`${s.environment}:${s.name}`}
+              name={s.name}
+              environment={s.environment}
+              readOnly={readOnly}
+              onReveal={vault.revealSecret}
+              onUpdate={vault.updateSecret}
+              onRename={vault.renameSecret}
+              onDelete={vault.deleteSecret}
+            />
+          ))
+        )}
+      </Stack>
+
+      {readOnly ? (
+        <Text size={'xs'} c={'dimmed'}>
+          Shared with you, read-only.
+        </Text>
+      ) : (
+        <AddSecretForm
+          disabled={vault.busy}
+          onSubmit={vault.addSecret}
+        />
+      )}
+    </>
+  );
+
   return (
     <MainWrapper>
       <Stack gap={'xl'} w={'100%'}>
@@ -229,7 +268,7 @@ export const VaultPage = () => {
           </Menu>
 
           <Group gap={'sm'}>
-            {canShare && (
+            {owned && (
               <Button
                 size={'xs'}
                 variant={'default'}
@@ -305,11 +344,11 @@ export const VaultPage = () => {
           </Tabs.List>
 
           <Tabs.Panel value={'environments'}>
-            <Stack gap={'lg'} pl={'md'}>
+            <Stack gap={'sm'} pl={'md'}>
               <Tabs
                 value={vault.activeEnv}
                 onChange={(env) => env && vault.switchEnv(env)}
-                variant="outline"
+                classNames={{ root: classes.envTabs }}
               >
                 <Tabs.List>
                   {vault.environments.map((env) => (
@@ -325,62 +364,48 @@ export const VaultPage = () => {
                 </Tabs.List>
               </Tabs>
 
-              <Accordion
-                multiple
-                defaultValue={[
-                  SECRETS_SECTION.id,
-                  API_KEYS_SECTION.id,
-                ]}
-              >
-                <Accordion.Item value={SECRETS_SECTION.id}>
-                  <Accordion.Control icon={<IconLockOpen size={20} />} p={0}>
-                    {SECRETS_SECTION.title}
-                  </Accordion.Control>
-                  <Accordion.Panel>
-                    <Stack gap={4}>
-                      {filtered.length === 0 ? (
-                        <Text size={'sm'} c={'dimmed'}>
-                          No secrets yet for <b>{vault.activeEnv}</b>.
-                        </Text>
-                      ) : (
-                        filtered.map((s) => (
-                          <SecretRow
-                            key={`${s.environment}:${s.name}`}
-                            name={s.name}
-                            environment={s.environment}
-                            readOnly={readOnly}
-                            onReveal={vault.revealSecret}
-                            onUpdate={vault.updateSecret}
-                            onRename={vault.renameSecret}
-                            onDelete={vault.deleteSecret}
-                          />
-                        ))
-                      )}
-                    </Stack>
-
-                    {readOnly ? (
-                      <Text size={'xs'} c={'dimmed'}>
-                        Shared with you, read-only.
+              {owned ? (
+                <Accordion
+                  multiple
+                  classNames={{ control: classes.sectionControl }}
+                  defaultValue={[
+                    SECRETS_SECTION.id,
+                    API_KEYS_SECTION.id,
+                  ]}
+                >
+                  <Accordion.Item value={SECRETS_SECTION.id}>
+                    <Accordion.Control
+                      icon={<IconLockOpen size={20} />}
+                    >
+                      {SECRETS_SECTION.title}
+                    </Accordion.Control>
+                    <Accordion.Panel>
+                      {secretsSection}
+                    </Accordion.Panel>
+                  </Accordion.Item>
+                  <Accordion.Item value={API_KEYS_SECTION.id}>
+                    <Accordion.Control icon={<IconKey size={20} />}>
+                      {API_KEYS_SECTION.title}
+                    </Accordion.Control>
+                    <Accordion.Panel>
+                      <Text size={'sm'} c={'dimmed'}>
+                        No API keys yet for <b>{vault.activeEnv}</b>.
                       </Text>
-                    ) : (
-                      <AddSecretForm
-                        disabled={vault.busy}
-                        onSubmit={vault.addSecret}
+                      {/* Issuing keys isn't wired up yet. */}
+                      <AddRowButton
+                        label={'Add API key'}
+                        onClick={() => {}}
                       />
-                    )}
-                  </Accordion.Panel>
-                </Accordion.Item>
-                <Accordion.Item value={API_KEYS_SECTION.id}>
-                  <Accordion.Control icon={<IconKey size={20} />}>
-                    {API_KEYS_SECTION.title}
-                  </Accordion.Control>
-                  <Accordion.Panel>{'API keys here'}</Accordion.Panel>
-                </Accordion.Item>
-              </Accordion>
+                    </Accordion.Panel>
+                  </Accordion.Item>
+                </Accordion>
+              ) : (
+                secretsSection
+              )}
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value={'credentials'}>
+          <Tabs.Panel value={'credentials'} pl={'md'}>
             <CredentialsTab
               vaultName={vault.activeVaultName}
               cloudName={vault.activeVault?.cloud?.name}

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  Accordion,
   ActionIcon,
   Alert,
   Box,
@@ -19,11 +20,13 @@ import {
 } from '@mantine/core';
 import {
   IconAlertCircle,
+  IconCertificate,
   IconCheck,
   IconCloud,
   IconCloudOff,
   IconFileImport,
   IconKey,
+  IconLockOpen,
   IconPlus,
   IconSelector,
   IconShare,
@@ -84,6 +87,16 @@ const NewEnvironmentInput = ({
       )}
     </Box>
   );
+};
+
+const SECRETS_SECTION = {
+  id: 'secrets',
+  title: 'Secrets',
+};
+
+const API_KEYS_SECTION = {
+  id: 'api-keys',
+  title: 'API Keys',
 };
 
 export const VaultPage = () => {
@@ -172,7 +185,7 @@ export const VaultPage = () => {
 
   return (
     <MainWrapper>
-      <Stack gap={'lg'} w={'100%'}>
+      <Stack gap={'xl'} w={'100%'}>
         <Group justify={'space-between'}>
           <Menu position={'bottom-start'} width={220}>
             <Menu.Target>
@@ -223,7 +236,7 @@ export const VaultPage = () => {
                 leftSection={<IconShare size={14} />}
                 onClick={() => setShareModalOpen(true)}
               >
-                Share vault
+                Share
               </Button>
             )}
             <Tooltip
@@ -249,9 +262,7 @@ export const VaultPage = () => {
                 loading={vault.busy}
                 onClick={() => void vault.toggleCloudSync()}
               >
-                {vault.cloudSync
-                  ? 'Cloud synced'
-                  : 'Enable cloud sync'}
+                {vault.cloudSync ? 'Synced' : 'Enable cloud sync'}
               </Button>
             </Tooltip>
           </Group>
@@ -273,7 +284,6 @@ export const VaultPage = () => {
           variant={'pills'}
         >
           <Tabs.List
-            w={190}
             pr={'md'}
             style={{
               borderRight:
@@ -288,17 +298,18 @@ export const VaultPage = () => {
             </Tabs.Tab>
             <Tabs.Tab
               value={'credentials'}
-              leftSection={<IconKey size={16} />}
+              leftSection={<IconCertificate size={16} />}
             >
               Credentials
             </Tabs.Tab>
           </Tabs.List>
 
-          <Tabs.Panel value={'environments'} pl={'lg'}>
-            <Stack gap={'lg'}>
+          <Tabs.Panel value={'environments'}>
+            <Stack gap={'lg'} pl={'md'}>
               <Tabs
                 value={vault.activeEnv}
                 onChange={(env) => env && vault.switchEnv(env)}
+                variant="outline"
               >
                 <Tabs.List>
                   {vault.environments.map((env) => (
@@ -314,41 +325,62 @@ export const VaultPage = () => {
                 </Tabs.List>
               </Tabs>
 
-              <Stack gap={4}>
-                {filtered.length === 0 ? (
-                  <Text size={'sm'} c={'dimmed'}>
-                    No secrets yet for <b>{vault.activeEnv}</b>.
-                  </Text>
-                ) : (
-                  filtered.map((s) => (
-                    <SecretRow
-                      key={`${s.environment}:${s.name}`}
-                      name={s.name}
-                      environment={s.environment}
-                      readOnly={readOnly}
-                      onReveal={vault.revealSecret}
-                      onUpdate={vault.updateSecret}
-                      onRename={vault.renameSecret}
-                      onDelete={vault.deleteSecret}
-                    />
-                  ))
-                )}
-              </Stack>
+              <Accordion
+                multiple
+                defaultValue={[
+                  SECRETS_SECTION.id,
+                  API_KEYS_SECTION.id,
+                ]}
+              >
+                <Accordion.Item value={SECRETS_SECTION.id}>
+                  <Accordion.Control icon={<IconLockOpen size={20} />} p={0}>
+                    {SECRETS_SECTION.title}
+                  </Accordion.Control>
+                  <Accordion.Panel>
+                    <Stack gap={4}>
+                      {filtered.length === 0 ? (
+                        <Text size={'sm'} c={'dimmed'}>
+                          No secrets yet for <b>{vault.activeEnv}</b>.
+                        </Text>
+                      ) : (
+                        filtered.map((s) => (
+                          <SecretRow
+                            key={`${s.environment}:${s.name}`}
+                            name={s.name}
+                            environment={s.environment}
+                            readOnly={readOnly}
+                            onReveal={vault.revealSecret}
+                            onUpdate={vault.updateSecret}
+                            onRename={vault.renameSecret}
+                            onDelete={vault.deleteSecret}
+                          />
+                        ))
+                      )}
+                    </Stack>
 
-              {readOnly ? (
-                <Text size={'xs'} c={'dimmed'}>
-                  Shared with you, read-only.
-                </Text>
-              ) : (
-                <AddSecretForm
-                  disabled={vault.busy}
-                  onSubmit={vault.addSecret}
-                />
-              )}
+                    {readOnly ? (
+                      <Text size={'xs'} c={'dimmed'}>
+                        Shared with you, read-only.
+                      </Text>
+                    ) : (
+                      <AddSecretForm
+                        disabled={vault.busy}
+                        onSubmit={vault.addSecret}
+                      />
+                    )}
+                  </Accordion.Panel>
+                </Accordion.Item>
+                <Accordion.Item value={API_KEYS_SECTION.id}>
+                  <Accordion.Control icon={<IconKey size={20} />}>
+                    {API_KEYS_SECTION.title}
+                  </Accordion.Control>
+                  <Accordion.Panel>{'API keys here'}</Accordion.Panel>
+                </Accordion.Item>
+              </Accordion>
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value={'credentials'} pl={'lg'}>
+          <Tabs.Panel value={'credentials'}>
             <CredentialsTab
               vaultName={vault.activeVaultName}
               cloudName={vault.activeVault?.cloud?.name}

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -35,8 +35,8 @@ import {
 import { MainWrapper } from '../components/MainWrapper';
 import classes from './Vault.module.css';
 import { useVault } from '../hooks/use-vault';
-import { AddRowButton } from '../components/vault/AddRowButton';
 import { AddSecretForm } from '../components/vault/AddSecretForm';
+import { ApiKeysSection } from '../components/vault/ApiKeysSection';
 import { CreateVaultModal } from '../components/vault/CreateVaultModal';
 import { CredentialsTab } from '../components/vault/CredentialsTab';
 import { SecretRow } from '../components/vault/SecretRow';
@@ -391,13 +391,10 @@ export const VaultPage = () => {
                       {API_KEYS_SECTION.title}
                     </Accordion.Control>
                     <Accordion.Panel>
-                      <Text size={'sm'} c={'dimmed'}>
-                        No API keys yet for <b>{vault.activeEnv}</b>.
-                      </Text>
-                      {/* Issuing keys isn't wired up yet. */}
-                      <AddRowButton
-                        label={'Add API key'}
-                        onClick={() => {}}
+                      <ApiKeysSection
+                        vaultName={vault.activeVaultName}
+                        cloudName={vault.activeVault?.cloud?.name}
+                        environment={vault.activeEnv}
                       />
                     </Accordion.Panel>
                   </Accordion.Item>

--- a/shared/components/atoms/MainWrapper.tsx
+++ b/shared/components/atoms/MainWrapper.tsx
@@ -9,7 +9,7 @@ export const MainWrapper = ({
 } & ContainerProps) => {
   return (
     <Container
-      maw={'700px'}
+      maw={'750px'}
       mih={'calc(100vh - 225px)'}
       p={0}
       display={'flex'}

--- a/shared/lib/constants.ts
+++ b/shared/lib/constants.ts
@@ -90,3 +90,7 @@ export enum VaultTokenAccess {
 // Shared secret header for first-party service-to-service calls
 // (e.g. web billing webhooks → Worker vault lock/unlock)
 export const SERVICE_TOKEN_HEADER = 'x-deadrop-service-token';
+
+export enum AuthScopes {
+  VaultInject = 'vault:inject',
+}

--- a/specs/cli-inject-command.md
+++ b/specs/cli-inject-command.md
@@ -13,7 +13,7 @@
   path (no `.deadroprc`/`--config` file at all — just env vars); (4) the
   `cli/install.sh` fix that would otherwise hang in CI. Issuance landed too,
   which this doc never specced: `deadrop apiKeys create` and `POST
-  /auth/key` scope a key to one vault + environment, and `--ci` reads both
+  /auth/keys` scope a key to one vault + environment, and `--ci` reads both
   off its claims, so `DEADROP_VAULT`/`DEADROP_ENVIRONMENT` are unnecessary.
 - **`--github-env` — still open.** Item (3): an output mode that persists
   secrets across an entire CI job instead of wrapping one command. The

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -128,7 +128,7 @@ Only by rotating the vault's credentials, which kills every token including your
 
 ### What features require a paid plan?
 
-The free tier covers unlimited drops, grabs, local vaults, and the CLI. Paid plans add cloud-synced vaults, the VS Code extension, CI/CD service tokens, sharing a vault read-only with someone else, and (on Pro+) write delegation for collaborators. See the [pricing page](/pricing) for the full comparison.
+The free tier covers 5 drops a day, unlimited grabs, local vaults, and the CLI. Paid plans add cloud-synced vaults, the VS Code extension, CI/CD service tokens, sharing a vault read-only with someone else, and (on Pro+) write delegation for collaborators. See the [pricing page](/pricing) for the full comparison.
 
 ### Can I self-host deadrop?
 

--- a/web/pages/docs/features/desktop.mdx
+++ b/web/pages/docs/features/desktop.mdx
@@ -97,6 +97,12 @@ cloud sync for a vault from the same view, so its secrets stay available across 
 can also link an existing project-scoped vault created by the CLI or the VS Code extension
 into the desktop app via "Import vault" in the vault switcher.
 
+If you own the cloud vault, each environment splits into Secrets and API Keys sections. The
+API Keys section lists the CI service tokens scoped to that vault and environment, with their
+status, and issues new ones without dropping to the CLI. A newly issued key is shown once, so
+copy it before closing the dialog. A local vault, or one shared with you, shows the plain
+secrets list instead, since there are no keys to manage there.
+
 Cloud-synced vaults also get a Credentials tab: it shows the token the app syncs with, issues
 new ones with an access level and expiry, and offers a break-glass rotate. Rotating kills every
 token for that vault, including your other machines and anyone you've shared it with, so the

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -72,7 +72,7 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### CI/CD
 
-- **CI service tokens**: issue a key scoped to one vault and environment with `deadrop apiKeys create`, then `deadrop inject --ci` runs a pipeline step with nothing but that key and the environment's decryption key set. Each run mints its own read-only token that expires in five minutes, replacing the long-lived token in a CI config. Currently gated to early-access accounts.
+- **CI service tokens**: issue a key scoped to one vault and environment with `deadrop apiKeys create`, or from the API Keys section of the desktop app's vault page, which also lists the keys already issued for that environment. Then `deadrop inject --ci` runs a pipeline step with nothing but that key and the environment's decryption key set. Each run mints its own read-only token that expires in five minutes, replacing the long-lived token in a CI config. Currently gated to early-access accounts.
 
 <DocsSectionTitle
   id={'in-progress'}

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -46,7 +46,7 @@ All keys are exchanged through peer-to-peer connections over WebRTC allowing all
 - 🧪 Desktop app (macOS/Windows/Linux, experimental)
 - 🧪 multidrop: multiple recipients per drop (Supporter+)
 - 🧪 vault sharing: hand a cloud vault to someone else over a drop (read-only, expiring)
-- 🧪 CI/CD service tokens: scoped API keys for pipelines (`deadrop apiKeys create`)
+- 🧪 CI/CD service tokens: scoped API keys for pipelines (`deadrop apiKeys create`, or the desktop vault page)
 - ⬜️ drop passcode protection
 - ⬜️ dynamic QR codes
 

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -49,7 +49,7 @@ worker/
 |--------|------|-------------|
 | GET | `/` | Health check (API metadata) |
 | `*` | `/auth/*` | Clerk auth endpoints |
-| POST | `/auth/key` | Issue a `vault:inject` API key whose claims carry the caller's resolved vault + environment (`authenticated()` + `restricted()`) |
+| POST | `/auth/keys` | Issue a `vault:inject` API key whose claims carry the caller's resolved vault + environment (`authenticated()` + `restricted()`) |
 | `*` | `/peers/*` | PeerJS signaling via `PeerServerDO` — implemented but not live (see top of file); production uses `peers.deadrop.io` on Render |
 | GET/POST/DELETE | `/drop` | Drop session CRUD (Redis) |
 | POST | `/vault` | Create a Turso vault database (`authenticated({ allowApiKey: true })` + `restricted()`) |

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -49,6 +49,7 @@ worker/
 |--------|------|-------------|
 | GET | `/` | Health check (API metadata) |
 | `*` | `/auth/*` | Clerk auth endpoints |
+| GET | `/auth/keys` | List the caller's `vault:inject` API keys for a vault + environment, filtered by scope and claims, returning `id`/`name`/`expired`/`revoked` only (`authenticated()` + `restricted()`) |
 | POST | `/auth/keys` | Issue a `vault:inject` API key whose claims carry the caller's resolved vault + environment (`authenticated()` + `restricted()`) |
 | `*` | `/peers/*` | PeerJS signaling via `PeerServerDO` — implemented but not live (see top of file); production uses `peers.deadrop.io` on Render |
 | GET/POST/DELETE | `/drop` | Drop session CRUD (Redis) |
@@ -107,7 +108,7 @@ worker/
 - Main: `src/index.ts`
 - Domain: `deadrop.nieky.dev`
 - DO: `PeerServerDO` class (binding `PEER_SERVER`)
-- Vars: `DAILY_DROP_LIMIT=5` (the Turso org slug is the shared `TURSO_ORGANIZATION` constant in `shared/lib/constants.ts`, not an env var)
+- Vars: `DAILY_DROP_LIMIT=5` — anonymous drops only, counted per IP; signed-in droppers count per `userId` against `PLAN_LIMITS.free.dailyDrops` (`shared/config/plans.ts`) until the limit reads off the user's plan (the Turso org slug is the shared `TURSO_ORGANIZATION` constant in `shared/lib/constants.ts`, not an env var)
 - Observability: logs + invocation logs enabled
 
 ## Path Aliases (tsconfig.json)

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -25,7 +25,7 @@ export const AppRouteParts = {
   AuthRoot: '/auth',
   CreateSignInToken: '/token',
   Me: '/me',
-  CreateApiKey: '/key',
+  ApiKeys: '/keys',
 
   // peerjs
   PeerJsRoot: '/peerjs',

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -10,10 +10,6 @@ export enum ContentType {
   Json = 'application/json',
 }
 
-export enum AuthScopes {
-  VaultInject = 'vault:inject',
-}
-
 export type AppRouteParts =
   (typeof AppRouteParts)[keyof typeof AppRouteParts];
 

--- a/worker/src/lib/auth.ts
+++ b/worker/src/lib/auth.ts
@@ -1,0 +1,11 @@
+import z from 'zod';
+import { VaultInjectClaimsSchema } from './vault';
+import { AuthScopes } from '../constants';
+
+export const ApiKeyClaimsFilterSchema =
+  VaultInjectClaimsSchema.partial();
+
+export const ListApiKeysOptionsSchema = z.object({
+  scopes: z.array(z.nativeEnum(AuthScopes)).optional(),
+  claims: z.any().optional(),
+});

--- a/worker/src/lib/auth.ts
+++ b/worker/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 import { VaultInjectClaimsSchema } from './vault';
-import { AuthScopes } from '../constants';
+import { AuthScopes } from '@shared/lib/constants';
 
 export const ApiKeyClaimsFilterSchema =
   VaultInjectClaimsSchema.partial();

--- a/worker/src/lib/auth.ts
+++ b/worker/src/lib/auth.ts
@@ -5,7 +5,16 @@ import { AuthScopes } from '@shared/lib/constants';
 export const ApiKeyClaimsFilterSchema =
   VaultInjectClaimsSchema.partial();
 
-export const ListApiKeysOptionsSchema = z.object({
-  scopes: z.array(z.nativeEnum(AuthScopes)).optional(),
-  claims: z.any().optional(),
+// Claims can't nest in a query string, so they arrive flattened, and a
+// repeated `scopes` param comes through as an array of one or more.
+export const ListApiKeysQuerySchema = VaultInjectClaimsSchema.extend({
+  scopes: z
+    .union([
+      z.nativeEnum(AuthScopes),
+      z.array(z.nativeEnum(AuthScopes)),
+    ])
+    .transform((scopes) =>
+      Array.isArray(scopes) ? scopes : [scopes],
+    )
+    .optional(),
 });

--- a/worker/src/lib/http/core.ts
+++ b/worker/src/lib/http/core.ts
@@ -1,6 +1,7 @@
 import { Hono, MiddlewareHandler } from 'hono';
 import { RequestIdVariables } from 'hono/request-id';
 import { Redis } from '@upstash/redis/cloudflare';
+import { ClerkHonoVariables } from '@clerk/hono';
 
 export type HonoCtx = {
   Bindings: Env;
@@ -11,7 +12,8 @@ export type HonoCtx = {
     claims?: Record<string, any>;
 
     redis: Redis;
-  } & RequestIdVariables;
+  } & RequestIdVariables &
+    ClerkHonoVariables;
 };
 
 export type Middleware = MiddlewareHandler<HonoCtx, string, {}>;

--- a/worker/src/lib/middleware.ts
+++ b/worker/src/lib/middleware.ts
@@ -1,11 +1,11 @@
 import { TokenType } from '@clerk/backend/internal';
 import { getAuth } from '@clerk/hono';
-import { SERVICE_TOKEN_HEADER } from '@shared/lib/constants';
+import { AuthScopes, SERVICE_TOKEN_HEADER } from '@shared/lib/constants';
 import { TEST_TOKEN_HEADER } from '@shared/tests/http';
 import { Redis } from '@upstash/redis/cloudflare';
 import { cors as baseCors } from 'hono/cors';
 import { createMiddleware } from 'hono/factory';
-import { AppHeaders, AuthScopes } from '../constants';
+import { AppHeaders } from '../constants';
 import { HonoCtx, Middleware } from './http/core';
 import {
   AuthUnavailable,

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -5,6 +5,11 @@ import { KeyNotIssued } from '../lib/messages';
 import { zValidator } from '@hono/zod-validator';
 import { vaultNameFromUserId } from '@shared/lib/turso';
 import { VaultInjectClaimsSchema } from '../lib/vault';
+import z from 'zod';
+import {
+  ApiKeyClaimsFilterSchema,
+  ListApiKeysOptionsSchema,
+} from '../lib/auth';
 
 const authRouter = hono()
   .get(
@@ -24,8 +29,35 @@ const authRouter = hono()
       return c.json({ token }, 200);
     },
   )
+  .get(
+    AppRouteParts.ApiKeys,
+    authenticated(),
+    restricted(),
+    zValidator('json', ListApiKeysOptionsSchema),
+    async (c) => {
+      const userId = c.get('userId')!;
+
+      const clerkClient = c.get('clerk');
+
+      const { data: userApiKeys } = await clerkClient.apiKeys.list({
+        subject: userId,
+      });
+
+      userApiKeys.filter(({ scopes, claims }) => {
+        let includeKey = false;
+
+        if (scopes.length === 0) return includeKey;
+
+        if (scopes.includes(AuthScopes.VaultInject) && claims)
+          includeKey =
+            ApiKeyClaimsFilterSchema.safeParse(claims).success;
+
+        return includeKey;
+      });
+    },
+  )
   .post(
-    AppRouteParts.CreateApiKey,
+    AppRouteParts.ApiKeys,
     authenticated(),
     restricted(),
     zValidator('json', VaultInjectClaimsSchema),

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -5,10 +5,9 @@ import { KeyNotIssued } from '../lib/messages';
 import { zValidator } from '@hono/zod-validator';
 import { vaultNameFromUserId } from '@shared/lib/turso';
 import { VaultInjectClaimsSchema } from '../lib/vault';
-import z from 'zod';
 import {
   ApiKeyClaimsFilterSchema,
-  ListApiKeysOptionsSchema,
+  ListApiKeysQuerySchema,
 } from '../lib/auth';
 import { AuthScopes } from '@shared/lib/constants';
 
@@ -34,7 +33,7 @@ const authRouter = hono()
     AppRouteParts.ApiKeys,
     authenticated(),
     restricted(),
-    zValidator('json', ListApiKeysOptionsSchema),
+    zValidator('query', ListApiKeysQuerySchema),
     async (c) => {
       const userId = c.get('userId')!;
 
@@ -44,17 +43,40 @@ const authRouter = hono()
         subject: userId,
       });
 
-      userApiKeys.filter(({ scopes, claims }) => {
-        let includeKey = false;
+      const {
+        scopes: scopesFilter,
+        vaultName: vaultNameFilter,
+        environment: environmentFilter,
+      } = c.req.valid('query');
 
-        if (scopes.length === 0) return includeKey;
+      const keys = userApiKeys
+        .filter(({ scopes, claims }) => {
+          if (scopes.length === 0) return false;
 
-        if (scopes.includes(AuthScopes.VaultInject) && claims)
-          includeKey =
-            ApiKeyClaimsFilterSchema.safeParse(claims).success;
+          if (
+            scopesFilter &&
+            !scopes.some((scope) =>
+              scopesFilter.includes(scope as AuthScopes),
+            )
+          )
+            return false;
 
-        return includeKey;
-      });
+          if (!ApiKeyClaimsFilterSchema.safeParse(claims).success)
+            return false;
+
+          return (
+            claims?.vaultName === vaultNameFilter &&
+            claims?.environment === environmentFilter
+          );
+        })
+        .map((key) => ({
+          id: key.id,
+          name: key.name,
+          expired: key.expired,
+          revoked: key.revoked,
+        }));
+
+      return c.json(keys, 200);
     },
   )
   .post(

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -1,4 +1,4 @@
-import { AppRouteParts, AuthScopes } from '../constants';
+import { AppRouteParts } from '../constants';
 import { hono } from '../lib/http/core';
 import { authenticated, restricted } from '../lib/middleware';
 import { KeyNotIssued } from '../lib/messages';
@@ -10,6 +10,7 @@ import {
   ApiKeyClaimsFilterSchema,
   ListApiKeysOptionsSchema,
 } from '../lib/auth';
+import { AuthScopes } from '@shared/lib/constants';
 
 const authRouter = hono()
   .get(

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -45,9 +45,13 @@ const authRouter = hono()
 
       const {
         scopes: scopesFilter,
-        vaultName: vaultNameFilter,
+        vaultName: name,
         environment: environmentFilter,
       } = c.req.valid('query');
+
+      // Claims carry the resolved cloud name, so match how issuance
+      // derives it rather than comparing the caller's local name.
+      const vaultNameFilter = await vaultNameFromUserId(userId, name);
 
       const keys = userApiKeys
         .filter(({ scopes, claims }) => {

--- a/worker/src/routers/drop.ts
+++ b/worker/src/routers/drop.ts
@@ -14,6 +14,7 @@ import {
   TEST_TOKEN_HEADER,
   testTokenKey,
 } from '@shared/tests/http';
+import { PLAN_LIMITS } from '@shared/config/plans';
 
 const dropIdSchema = z.object({ id: z.string() });
 
@@ -73,12 +74,20 @@ const dropRouter = hono()
         if (!allowed) return c.json(PermissionDenied, 403);
       }
 
-      const canDrop = isTestSession
-        ? true
-        : await checkAndIncrementUserDropCount(ipAddress!);
+      if (!isTestSession) {
+        const userId = c.get('userId');
 
-      if (!canDrop)
-        return c.json({ message: 'Daily drop limit reached' }, 500);
+        // TODO dynamic limit check based off of user plan
+        const canDrop = !!userId
+          ? await checkAndIncrementAuthUserDropCount(
+              userId,
+              PLAN_LIMITS.free.dailyDrops,
+            )
+          : await checkAndIncrementUserDropCount(ipAddress!);
+
+        if (!canDrop)
+          return c.json({ message: 'Daily drop limit reached' }, 500);
+      }
 
       const { dropId, nonce } = await createDrop(
         peerId,

--- a/worker/src/routers/vault.ts
+++ b/worker/src/routers/vault.ts
@@ -1,12 +1,12 @@
 import { zValidator } from '@hono/zod-validator';
-import { AppRouteParts, AuthScopes } from '../constants';
+import { AppRouteParts } from '../constants';
 import { hono } from '../lib/http/core';
 import {
   createVaultUtils,
   vaultNameFromUserId,
   TursoApiError,
 } from '@shared/lib/turso';
-import { VaultTokenAccess } from '@shared/lib/constants';
+import { AuthScopes, VaultTokenAccess } from '@shared/lib/constants';
 import {
   MintedVaultCreds,
   VaultApiKeyCreds,

--- a/worker/tests/lib/auth.spec.ts
+++ b/worker/tests/lib/auth.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { AuthScopes } from '@shared/lib/constants';
+import { ListApiKeysQuerySchema } from '../../src/lib/auth';
+
+const target = { vaultName: 'demo', environment: 'production' };
+
+describe('ListApiKeysQuerySchema', () => {
+  // Hono hands a single query param through as a string and only makes
+  // an array when it repeats, so both shapes reach the schema.
+  it('lifts a single scope param into an array', () => {
+    const parsed = ListApiKeysQuerySchema.parse({
+      ...target,
+      scopes: AuthScopes.VaultInject,
+    });
+
+    expect(parsed.scopes).toEqual([AuthScopes.VaultInject]);
+  });
+
+  it('keeps a repeated scope param as an array', () => {
+    const parsed = ListApiKeysQuerySchema.parse({
+      ...target,
+      scopes: [AuthScopes.VaultInject, AuthScopes.VaultInject],
+    });
+
+    expect(parsed.scopes).toEqual([
+      AuthScopes.VaultInject,
+      AuthScopes.VaultInject,
+    ]);
+  });
+
+  it('treats scopes as optional', () => {
+    expect(ListApiKeysQuerySchema.parse(target).scopes).toBeUndefined();
+  });
+
+  it('rejects a scope outside the known set', () => {
+    expect(
+      ListApiKeysQuerySchema.safeParse({
+        ...target,
+        scopes: 'vault:everything',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('requires both halves of the vault target', () => {
+    expect(
+      ListApiKeysQuerySchema.safeParse({ vaultName: 'demo' }).success,
+    ).toBe(false);
+    expect(
+      ListApiKeysQuerySchema.safeParse({ environment: 'production' })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/worker/tests/routers/auth-keys.spec.ts
+++ b/worker/tests/routers/auth-keys.spec.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMiddleware } from 'hono/factory';
+import { AuthScopes } from '@shared/lib/constants';
+
+const list = vi.fn();
+const create = vi.fn();
+
+vi.mock('../../src/lib/middleware', () => ({
+  authenticated: () => createMiddleware(async (_c, next) => next()),
+  restricted: () =>
+    createMiddleware(async (c, next) => {
+      c.set('userId', 'user_123');
+      c.set('clerk', { apiKeys: { list, create } });
+      await next();
+    }),
+  apiKey: () => createMiddleware(async (_c, next) => next()),
+  service: () => createMiddleware(async (_c, next) => next()),
+}));
+
+vi.mock('@shared/lib/turso', async () => {
+  const actual = await vi.importActual<
+    typeof import('@shared/lib/turso')
+  >('@shared/lib/turso');
+  return {
+    ...actual,
+    vaultNameFromUserId: vi.fn(
+      async (_userId: string, name?: string) =>
+        name ? `hash13-${name}` : 'hash13',
+    ),
+  };
+});
+
+const testEnv = {};
+
+const key = (over: Record<string, unknown> = {}) => ({
+  id: 'key_1',
+  name: 'hash13-demo production Key',
+  expired: false,
+  revoked: false,
+  scopes: [AuthScopes.VaultInject],
+  claims: { vaultName: 'hash13-demo', environment: 'production' },
+  secret: 'sk_should_never_leak',
+  ...over,
+});
+
+const listKeys = async (query: string) => {
+  const authRouter = (await import('../../src/routers/auth')).default;
+
+  return authRouter.request(`/keys?${query}`, {}, testEnv);
+};
+
+describe('GET /auth/keys', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // The claims store the resolved cloud name, so a filter that compared
+  // the caller's local name straight from the query matched nothing.
+  it('matches claims against the resolved cloud vault name', async () => {
+    list.mockResolvedValue({ data: [key()] });
+
+    const res = await listKeys(
+      'vaultName=demo&environment=production',
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        id: 'key_1',
+        name: 'hash13-demo production Key',
+        expired: false,
+        revoked: false,
+      },
+    ]);
+    expect(list).toHaveBeenCalledWith({ subject: 'user_123' });
+  });
+
+  it('never returns the key secret', async () => {
+    list.mockResolvedValue({ data: [key()] });
+
+    const res = await listKeys(
+      'vaultName=demo&environment=production',
+    );
+
+    expect(JSON.stringify(await res.json())).not.toContain(
+      'sk_should_never_leak',
+    );
+  });
+
+  it('drops keys claimed for another vault or environment', async () => {
+    list.mockResolvedValue({
+      data: [
+        key({
+          id: 'other_vault',
+          claims: {
+            vaultName: 'hash13-elsewhere',
+            environment: 'production',
+          },
+        }),
+        key({
+          id: 'other_env',
+          claims: {
+            vaultName: 'hash13-demo',
+            environment: 'staging',
+          },
+        }),
+      ],
+    });
+
+    const res = await listKeys(
+      'vaultName=demo&environment=production',
+    );
+
+    expect(await res.json()).toEqual([]);
+  });
+
+  it('drops keys without the requested scope', async () => {
+    list.mockResolvedValue({
+      data: [key({ id: 'wrong_scope', scopes: ['something:else'] })],
+    });
+
+    const res = await listKeys(
+      `vaultName=demo&environment=production&scopes=${AuthScopes.VaultInject}`,
+    );
+
+    expect(await res.json()).toEqual([]);
+  });
+
+  it('drops keys carrying no scopes at all', async () => {
+    list.mockResolvedValue({ data: [key({ scopes: [] })] });
+
+    const res = await listKeys(
+      'vaultName=demo&environment=production',
+    );
+
+    expect(await res.json()).toEqual([]);
+  });
+
+  it('rejects a request missing the vault target', async () => {
+    const res = await listKeys('vaultName=demo');
+
+    expect(res.status).toBe(400);
+    expect(list).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/keys', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('issues a scoped key against the resolved vault name', async () => {
+    create.mockResolvedValue({
+      id: 'key_1',
+      name: 'issued',
+      secret: 'sk_live_123',
+    });
+
+    const authRouter = (await import('../../src/routers/auth'))
+      .default;
+    const res = await authRouter.request(
+      '/keys',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          vaultName: 'demo',
+          environment: 'production',
+        }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      id: 'key_1',
+      name: 'issued',
+      key: 'sk_live_123',
+    });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'user_123',
+        scopes: [AuthScopes.VaultInject],
+        claims: {
+          vaultName: 'hash13-demo',
+          environment: 'production',
+        },
+      }),
+    );
+  });
+
+  // Clerk returns the plaintext only on create, so a key we cannot hand
+  // back is unusable and must not read as success.
+  it('fails when Clerk returns no secret', async () => {
+    create.mockResolvedValue({ id: 'key_1', name: 'issued' });
+
+    const authRouter = (await import('../../src/routers/auth'))
+      .default;
+    const res = await authRouter.request(
+      '/keys',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          vaultName: 'demo',
+          environment: 'production',
+        }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/worker/tests/routers/drop-limits.spec.ts
+++ b/worker/tests/routers/drop-limits.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PLAN_LIMITS } from '@shared/config/plans';
+import { hono } from '../../src/lib/http/core';
+
+const createDrop = vi.fn();
+const checkAndIncrementUserDropCount = vi.fn();
+const checkAndIncrementAuthUserDropCount = vi.fn();
+
+vi.mock('../../src/lib/cache', () => ({
+  createCacheHandlers: () => ({
+    createDrop,
+    checkAndIncrementUserDropCount,
+    checkAndIncrementAuthUserDropCount,
+  }),
+}));
+
+vi.mock('@clerk/hono', () => ({ getAuth: () => null }));
+
+const drop = async (userId?: string) => {
+  const dropRouter = (await import('../../src/routers/drop')).default;
+
+  const app = hono()
+    .use(async (c, next) => {
+      c.set('ipAddress', '203.0.113.7');
+      c.set('redis', { get: async () => null } as never);
+      if (userId) c.set('userId', userId);
+      await next();
+    })
+    .route('/', dropRouter);
+
+  return app.request(
+    '/',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'peer_1' }),
+    },
+    {},
+  );
+};
+
+describe('POST /drop daily limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDrop.mockResolvedValue({ dropId: 'drop_1', nonce: 'n_1' });
+    checkAndIncrementUserDropCount.mockResolvedValue(true);
+    checkAndIncrementAuthUserDropCount.mockResolvedValue(true);
+  });
+
+  it('counts a signed-in dropper against their own account', async () => {
+    const res = await drop('user_123');
+
+    expect(res.status).toBe(200);
+    expect(checkAndIncrementAuthUserDropCount).toHaveBeenCalledWith(
+      'user_123',
+      PLAN_LIMITS.free.dailyDrops,
+    );
+    // Two people behind one address must not share an allowance.
+    expect(checkAndIncrementUserDropCount).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the IP counter when anonymous', async () => {
+    const res = await drop();
+
+    expect(res.status).toBe(200);
+    expect(checkAndIncrementUserDropCount).toHaveBeenCalledWith(
+      '203.0.113.7',
+    );
+    expect(checkAndIncrementAuthUserDropCount).not.toHaveBeenCalled();
+  });
+
+  it('refuses the drop once a signed-in user is over the limit', async () => {
+    checkAndIncrementAuthUserDropCount.mockResolvedValue(false);
+
+    const res = await drop('user_123');
+
+    expect(res.status).toBe(500);
+    expect(createDrop).not.toHaveBeenCalled();
+  });
+
+  it('refuses the drop once an anonymous IP is over the limit', async () => {
+    checkAndIncrementUserDropCount.mockResolvedValue(false);
+
+    const res = await drop();
+
+    expect(res.status).toBe(500);
+    expect(createDrop).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two things, plus a drop-limit change that rode along.

**1. API keys in the desktop vault page.** The Environments pane splits into Secrets and API Keys sections, but only for a cloud vault you own. If the vault is local, or shared with you, you get the flat secrets list exactly as before, since there are no keys to manage and nothing to issue. The API Keys section lists the keys scoped to the active vault and environment with an Active/Expired/Revoked badge each, and issuing one opens a modal that confirms the target and then shows the plaintext key once, which is the only time Clerk returns it. Adding a secret moved into a modal at the same time, and both modals share a header showing which vault (local and cloud name) and environment you are writing to.

**2. `/auth/key` becomes the `/auth/keys` collection.** The route now serves `POST` for issuance and `GET` for listing, so the desktop app can read keys instead of sending people to the Clerk dashboard. `GET` filters by scope and by the caller's vault and environment claims, and returns `id`, `name`, `expired` and `revoked` only. It resolves the vault name through `vaultNameFromUserId` the same way issuance does, since claims store the resolved cloud name and comparing against a raw local name never matched. `AuthScopes` moved from `worker/src/constants.ts` into `shared/lib/constants.ts` so the desktop client can name the scope it is filtering on.

**3. Per-user drop counting.** Signed-in droppers are now counted against their own user id rather than their IP. The limit is still hardcoded to `PLAN_LIMITS.free.dailyDrops` for everyone, with a TODO for reading it off the user's plan.

## Before merging

**`POST /auth/key` is gone, and the worker auto-deploys on merge here.** The published CLI still calls it: I unpacked `deadrop@1.11.1` from npm, which is both the latest release and what `main` currently ships, and `dist/deadrop.js` contains `auth.key`. So the moment this deploys, `deadrop apiKeys create` returns 404 for every installed CLI until users upgrade. Either keep `/auth/key` registered as a deprecated alias for a release or two, or accept the break and ship a CLI release alongside the deploy. This does not affect drop, grab or inject, which never touched that route.

**No changeset covers the CLI change.** `cli/actions/apiKeys.ts` moved to the new path in this branch, but nothing queues a release, so the fixed CLI would not publish on its own.

**This branch is 3 commits behind `origin/main`.** `main` consumed `cli-ci-implies-no-sync.md` and `desktop-vault-sidebar.md` when it released cli@1.11.1 and desktop@0.3.3. Both files are still present here, so merging without pulling `main` in first resurrects them and re-releases the same notes.

## Test plan

- [ ] Sign in on desktop with a cloud vault you own, open the vault page, and confirm the Secrets and API Keys accordion renders
- [ ] Confirm a local-only vault and a vault shared with you both still show the flat secrets list with no API Keys section
- [ ] Issue a key from the UI, copy it, and confirm it authenticates `deadrop inject --ci`
- [ ] Confirm the issued key appears in the list after the modal closes, and that switching environments refetches
- [ ] Confirm keys issued by `deadrop apiKeys create` for the same vault and environment show up in the desktop list, since this is the claims match that changed
- [ ] Confirm the environment tabs render as the underline variant with no border box around the tab list
- [ ] Drop as a signed-in user and confirm the daily limit still applies, then drop anonymously and confirm the IP path still applies
