### PR TITLE
Desktop vault UI, cloud sync fix, and CI API key shaping claims

### DIFF
--- a/.changeset/api-key-inject-shaping-claims.md
+++ b/.changeset/api-key-inject-shaping-claims.md
@@ -1,0 +1,11 @@
+---
+'cli': minor
+'worker': minor
+'shared': minor
+---
+
+Let a CI API key carry the shaping for the runs that use it. `deadrop apiKeys create` takes `--only` to name the secrets the key injects and `--prefix` to rename them, both optional. The claims travel with the key, so a pipeline sets `DEADROP_API_KEY` and gets the right variables under the right names without repeating the flags at every call site.
+
+A run can narrow what the key allows but never widen it. `inject --only` may pick a subset of the key's list, and naming anything outside it fails rather than injecting it. An `inject --prefix` that disagrees with the key's warns and the key's prefix is used.
+
+These claims shape what `inject` writes into the process, not what the key can read. Secrets never pass through the worker, so filtering happens on your machine, and a short lived Turso token covers the whole vault database. What actually separates environments is that each one has its own encryption key: a key issued for `production` cannot decrypt anything from `development`. Secret names and environment names are stored unencrypted and stay visible across environments, the same way a committed `.env.example` lists names without values.

--- a/.changeset/republish-vscode-extension.md
+++ b/.changeset/republish-vscode-extension.md
@@ -1,0 +1,5 @@
+---
+'deadrop-vsc': patch
+---
+
+Republish the extension so every platform target is available. The 0.1.9 publish timed out against the marketplace API partway through uploading the per-platform builds, leaving `linux-x64` and `win32-x64` missing. Every vsix is platform specific, so there was no universal build for those users to fall back to and the extension could not be installed on Windows or on the most common Linux target. No extension code changes.

--- a/.github/workflows/cli_e2e_workflow.yml
+++ b/.github/workflows/cli_e2e_workflow.yml
@@ -45,9 +45,7 @@ jobs:
           # Runtime: initPeer reads the TURN creds from the env at run time.
           TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
           TURN_PWD: ${{ secrets.TURN_PWD }}
-          # The stable drop test token the dropper sends to bypass captcha/
-          # rate-limits. The worker verifies it against the persistent Redis
-          # value (test_tkn)
+          # The stable drop test token the clients send to bypass captcha
           DROP_TEST_TOKEN: ${{ secrets.DROP_TEST_TOKEN }}
         # test:e2e builds dist/deadrop.js, then runs the Vitest e2e config.
         run: CI=true pnpm -F cli test:e2e

--- a/.github/workflows/cli_publish_workflow.yml
+++ b/.github/workflows/cli_publish_workflow.yml
@@ -55,12 +55,6 @@ jobs:
           cd cli
           pnpm install --frozen-lockfile
           (cd node_modules/bun && node install.js)
-          export DEADROP_API_URL=$DEADROP_API_URL
-          export DEADROP_APP_URL=$DEADROP_APP_URL
-          export PEER_SERVER_URL=$PEER_SERVER_URL
-          export TURN_USERNAME=$TURN_USERNAME
-          export TURN_PWD=$TURN_PWD
-          export CLERK_PUBLISHABLE_KEY=$CLERK_PUBLISHABLE_KEY
           pnpm compile
       - name: Rename binary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,4 +128,20 @@ jobs:
         working-directory: vscode-extension
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: pnpm exec vsce publish --packagePath vsix/*.vsix
+        run: |
+          # vsce only retries timeouts on the signed publish path, and one throw there aborts every remaining target
+          failed=()
+          for vsix in vsix/*.vsix; do
+            for attempt in 1 2 3; do
+              if pnpm exec vsce publish --packagePath "$vsix"; then
+                continue 2
+              fi
+              echo "::warning::publish failed for $vsix (attempt $attempt/3)"
+              if [ "$attempt" -lt 3 ]; then sleep $((attempt * 15)); fi
+            done
+            failed+=("$vsix")
+          done
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::did not publish: ${failed[*]}"
+            exit 1
+          fi

--- a/cli/actions/apiKeys.ts
+++ b/cli/actions/apiKeys.ts
@@ -20,6 +20,8 @@ type CreateApiKeyOptions = {
   yes?: boolean;
   print?: boolean;
   copy?: boolean;
+  prefix?: string | undefined;
+  only?: string[] | undefined;
 };
 
 // A key mints Turso tokens for a remote database, so a local-only vault
@@ -175,7 +177,12 @@ export async function createApiKey(
 
   try {
     const response = await deadropClient.auth.keys.$post({
-      json: { vaultName, environment },
+      json: {
+        vaultName,
+        environment,
+        prefix: options.prefix,
+        only: options.only,
+      },
     });
 
     const data = await response.json();

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -1,4 +1,5 @@
 import { createSecretsHelpers } from '@shared/db/secrets';
+import { VaultInjectOptions } from '@shared/lib/vault-tokens';
 import { VaultDBConfig } from '@shared/types/config';
 import { randomBytes } from 'crypto';
 import { initDBClient } from 'db/init';
@@ -39,6 +40,8 @@ type ResolvedVault = {
   // vault.location is a temp replica we own and must clean up on exit.
   ephemeral: boolean;
   strategy: MintStrategy;
+  // Shaping carried by an API key's claims; absent on every other path.
+  claims?: VaultInjectOptions;
 };
 
 // `--ci` asserts the machine path is available rather than selecting it, so
@@ -160,15 +163,18 @@ async function applyMintStrategy(resolved: ResolvedVault) {
   try {
     // The worker prefixes the label it is given, so send the label — an
     // already-resolved name would get prefixed a second time.
-    const { name, token, environment } = isApiKey
+    const { name, token, environment, ...claims } = isApiKey
       ? await mintVaultTokenWithApiKey()
       : await mintVaultToken(vaultName);
 
     resolved.vault.cloud = { name, authToken: token };
 
-    // The key's claims, not the local label, decide which vault an API key
-    // run reads — adopt the resolved name so logs name what actually synced.
-    if (isApiKey) resolved.vaultName = name;
+    if (isApiKey) {
+      resolved.claims = claims;
+
+      // The key's claims, not the local label, decide which vault an API key
+      resolved.vaultName = name;
+    }
 
     if (environment) bindEnvironment(resolved, environment);
   } catch (err) {
@@ -215,18 +221,34 @@ async function parseVaultFromOptions(options: InjectOptions) {
 
 // --only names the stored secrets, so the list matches `vault env list`;
 // --prefix is applied after, renaming whatever survived the filter.
+// An API key's claims are the baseline: --only may narrow within them, and
+// a --prefix that disagrees with the key's loses.
 function shapeSecrets(
   secrets: Record<string, string>,
-  { only, prefix }: InjectOptions,
+  { only, prefix }: Pick<InjectOptions, 'only' | 'prefix'>,
+  claims: VaultInjectOptions = {},
 ) {
+  const requested = only
+    ?.split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+  if (requested && claims.only) {
+    const denied = requested.filter(
+      (name) => !claims.only!.includes(name),
+    );
+
+    if (denied.length) {
+      logError(`Not permitted by this API key: ${denied.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  const wanted = requested ?? claims.only;
+
   let shaped = secrets;
 
-  if (only) {
-    const wanted = only
-      .split(',')
-      .map((name) => name.trim())
-      .filter(Boolean);
-
+  if (wanted) {
     const missing = wanted.filter((name) => !(name in secrets));
 
     // A typo here would otherwise inject nothing and exit 0.
@@ -240,10 +262,17 @@ function shapeSecrets(
     );
   }
 
-  if (prefix)
+  if (claims.prefix && prefix && prefix !== claims.prefix)
+    logWarning(
+      `Ignoring --prefix: this API key applies '${claims.prefix}'.`,
+    );
+
+  const resolvedPrefix = claims.prefix ?? prefix;
+
+  if (resolvedPrefix)
     shaped = Object.fromEntries(
       Object.entries(shaped).map(([name, value]) => [
-        `${prefix}${name}`,
+        `${resolvedPrefix}${name}`,
         value,
       ]),
     );
@@ -262,12 +291,19 @@ export async function inject(
     process.exit(1);
   }
 
-  const { vaultName, environment, vault, ephemeral, strategy } =
-    await parseVaultFromOptions(options);
+  const {
+    vaultName,
+    environment,
+    vault,
+    ephemeral,
+    strategy,
+    claims,
+  } = await parseVaultFromOptions(options);
+
+  const isApiKey = strategy == MintStrategy.ApiKey;
 
   // CI tokens are read-only, and the replica is discarded anyway.
-  const sync =
-    strategy !== MintStrategy.ApiKey && options.sync !== false;
+  const sync = !isApiKey && options.sync !== false;
 
   const db = await initDBClient(vault.location, vault.cloud, sync);
 
@@ -276,6 +312,7 @@ export async function inject(
   const secrets = shapeSecrets(
     await getAllSecrets(environment),
     options,
+    claims,
   );
 
   const names = Object.keys(secrets);

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -288,6 +288,21 @@ use it as DEADROP_API_KEY with 'deadrop inject --ci'`,
     'environment to scope the key to (prompts to select when omitted)',
   )
   .option(
+    '--only <names>',
+    `comma-separated secrets this key injects (default: the whole environment)
+a run may narrow this further with 'inject --only', never widen it`,
+    (value: string) =>
+      value
+        .split(',')
+        .map((name) => name.trim())
+        .filter(Boolean),
+  )
+  .option(
+    '--prefix <prefix>',
+    `prepend this to every variable name the key injects
+overrides 'inject --prefix' for runs using the key`,
+  )
+  .option(
     '-y, --yes',
     'skip the confirmation prompt (also implied by a non-TTY shell or CI)',
   )

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -639,6 +639,112 @@ describe('inject', () => {
     );
   });
 
+  // An API key's claims are the baseline: --only narrows within them and a
+  // disagreeing --prefix loses, so a pipeline cannot widen its own key.
+  const injectWithClaims = async (
+    secrets: Record<string, string>,
+    claims: { only?: string[]; prefix?: string },
+    options: Record<string, unknown> = {},
+  ) => {
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } =
+      await import('@shared/db/secrets');
+    const { mintVaultTokenWithApiKey } =
+      await import('lib/auth/vault-token');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    process.env.DEADROP_VAULT_KEY = 'aes-key';
+    process.env.DEADROP_API_KEY = 'sk_test';
+
+    vi.mocked(mintVaultTokenWithApiKey).mockImplementation(
+      minted({
+        token: 'ci-token',
+        name: 'a1b2c3d4e5f67-my-app',
+        environment: 'production',
+        ...claims,
+      }),
+    );
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close: vi.fn() },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue(secrets),
+    } as any);
+    const runWithEnv = vi
+      .spyOn(processModule, 'runWithEnv')
+      .mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(
+      () => undefined as never,
+    );
+
+    await inject(['node'], { override: true, ci: true, ...options });
+
+    return runWithEnv;
+  };
+
+  it("CI: applies the key's only claim with no flags", async () => {
+    const runWithEnv = await injectWithClaims(
+      { DB_URL: 'a', API_KEY: 'b', STRIPE_KEY: 'c' },
+      { only: ['DB_URL', 'API_KEY'] },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({
+      DB_URL: 'a',
+      API_KEY: 'b',
+    });
+  });
+
+  it("CI: applies the key's prefix claim", async () => {
+    const runWithEnv = await injectWithClaims(
+      { DB_URL: 'a' },
+      { prefix: 'PROD_' },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({ PROD_DB_URL: 'a' });
+  });
+
+  it('CI: --only narrows within the claim', async () => {
+    const runWithEnv = await injectWithClaims(
+      { DB_URL: 'a', API_KEY: 'b' },
+      { only: ['DB_URL', 'API_KEY'] },
+      { only: 'DB_URL' },
+    );
+
+    expect(runWithEnv.mock.calls[0][2]).toEqual({ DB_URL: 'a' });
+  });
+
+  it('CI: --only exits 1 on a name the key does not permit', async () => {
+    const { logError } = await import('lib/log');
+
+    // injectWithClaims installs the process.exit spy, so assert on it.
+    await injectWithClaims(
+      { DB_URL: 'a', STRIPE_KEY: 'c' },
+      { only: ['DB_URL'] },
+      { only: 'STRIPE_KEY' },
+    );
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('Not permitted by this API key'),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("CI: a disagreeing --prefix warns and the key's prefix wins", async () => {
+    const { logWarning } = await import('lib/log');
+
+    const runWithEnv = await injectWithClaims(
+      { DB_URL: 'a' },
+      { prefix: 'PROD_' },
+      { prefix: 'STAGING_' },
+    );
+
+    expect(logWarning).toHaveBeenCalledWith(
+      expect.stringContaining("applies 'PROD_'"),
+    );
+    expect(runWithEnv.mock.calls[0][2]).toEqual({ PROD_DB_URL: 'a' });
+  });
+
   it('CI: --refresh-token does not knock the run off the API key path', async () => {
     const { initDBClient } = await import('db/init');
     const { createSecretsHelpers } =

--- a/desktop/src/hooks/use-vault.tsx
+++ b/desktop/src/hooks/use-vault.tsx
@@ -50,6 +50,7 @@ export const useVault = () => {
 
   const [config, setConfig] = useState<DeadropConfig | null>(null);
   const [secretNames, setSecretNames] = useState<SecretName[]>([]);
+  const [secretsLoading, setSecretsLoading] = useState(true);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,9 +92,15 @@ export const useVault = () => {
     })();
   }, []);
 
+  // Only the first read per vault flips the flag; refreshSecretNames runs
+  // after every mutation too, and skeletons on those would just flicker.
   useEffect(() => {
     if (!activeVault) return;
-    refreshSecretNames().catch((err) => setError((err as Error).message));
+
+    setSecretsLoading(true);
+    refreshSecretNames()
+      .catch((err) => setError((err as Error).message))
+      .finally(() => setSecretsLoading(false));
   }, [activeVault, refreshSecretNames]);
 
   const withBusy = useCallback(
@@ -481,6 +488,7 @@ export const useVault = () => {
     activeEnv,
     environments,
     secretNames,
+    secretsLoading,
     switchVault,
     switchEnv,
     createVault,

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -10,6 +10,7 @@ import {
   Group,
   Loader,
   Menu,
+  Skeleton,
   Stack,
   Tabs,
   Text,
@@ -206,7 +207,12 @@ export const VaultPage = () => {
   const secretsSection = (
     <>
       <Stack gap={4}>
-        {filtered.length === 0 ? (
+        {vault.secretsLoading ? (
+          // Match the row height so the list does not jump when it resolves.
+          Array.from({ length: 3 }, (_, i) => (
+            <Skeleton key={i} height={26} my={2} radius={'sm'} />
+          ))
+        ) : filtered.length === 0 ? (
           <Text size={'sm'} c={'dimmed'}>
             No secrets yet for <b>{vault.activeEnv}</b>.
           </Text>

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -390,7 +390,12 @@ export const VaultPage = () => {
             </Tabs.Tab>
           </Tabs.List>
 
-          <Tabs.Panel value={'environments'}>
+          <Tabs.Panel
+            value={'environments'}
+            // A flex item defaults to min-width auto, so without this a long
+            // secret widens the pane instead of ellipsising inside it.
+            style={{ flex: 1, minWidth: 0 }}
+          >
             <Stack gap={'sm'} pl={'md'}>
               <Tabs
                 value={vault.activeEnv}
@@ -449,7 +454,11 @@ export const VaultPage = () => {
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value={'credentials'} pl={'md'}>
+          <Tabs.Panel
+            value={'credentials'}
+            pl={'md'}
+            style={{ flex: 1, minWidth: 0 }}
+          >
             <CredentialsTab
               vaultName={vault.activeVaultName}
               cloudName={vault.activeVault?.cloud?.name}

--- a/shared/lib/vault-tokens.ts
+++ b/shared/lib/vault-tokens.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+export const VaultInjectOptionsSchema = z.object({
+  prefix: z.string().optional(),
+  only: z.array(z.string()).optional(),
+});
+
 // `name` is the resolved remote database name, not the local label —
 // vaultSyncUrl derives the sync URL from it.
 export const MintedVaultCredsSchema = z.object({
@@ -11,7 +16,11 @@ export const MintedVaultCredsSchema = z.object({
 
 export const VaultApiKeyCredsSchema = MintedVaultCredsSchema.extend({
   environment: z.string().min(1),
-});
+}).and(VaultInjectOptionsSchema);
+
+export type VaultInjectOptions = z.infer<
+  typeof VaultInjectOptionsSchema
+>;
 
 export type MintedVaultCreds = z.infer<typeof MintedVaultCredsSchema>;
 

--- a/worker/src/lib/auth.ts
+++ b/worker/src/lib/auth.ts
@@ -1,13 +1,12 @@
 import z from 'zod';
-import { VaultInjectClaimsSchema } from './vault';
+import { VaultEnvSchema } from './vault';
 import { AuthScopes } from '@shared/config/plans';
 
-export const ApiKeyClaimsFilterSchema =
-  VaultInjectClaimsSchema.partial();
+export const ApiKeyClaimsFilterSchema = VaultEnvSchema.partial();
 
 // Claims can't nest in a query string, so they arrive flattened, and a
 // repeated `scopes` param comes through as an array of one or more.
-export const ListApiKeysQuerySchema = VaultInjectClaimsSchema.extend({
+export const ListApiKeysQuerySchema = VaultEnvSchema.extend({
   scopes: z
     .union([
       z.nativeEnum(AuthScopes),

--- a/worker/src/lib/vault.ts
+++ b/worker/src/lib/vault.ts
@@ -1,4 +1,5 @@
 import { VaultTokenAccess } from '@shared/lib/constants';
+import { VaultInjectOptionsSchema } from '@shared/lib/vault-tokens';
 import z from 'zod';
 
 export const VaultNameSchema = z.object({ name: z.string() });
@@ -21,10 +22,12 @@ export const VaultTokenSchema = z.object({
   expiration: z.string().optional(),
 });
 
-export const VaultInjectClaimsSchema = z.object({
+export const VaultEnvSchema = z.object({
   vaultName: z.string(),
   environment: z.string(),
 });
+
+export const VaultInjectClaimsSchema = VaultEnvSchema.and(VaultInjectOptionsSchema);
 
 export type VaultInjectClaims = z.infer<
   typeof VaultInjectClaimsSchema

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -4,7 +4,10 @@ import { authenticated } from '../lib/middleware';
 import { KeyNotIssued } from '../lib/messages';
 import { zValidator } from '@hono/zod-validator';
 import { vaultNameFromUserId } from '@shared/lib/turso';
-import { VaultInjectClaimsSchema } from '../lib/vault';
+import {
+  VaultInjectClaims,
+  VaultInjectClaimsSchema,
+} from '../lib/vault';
 import {
   ApiKeyClaimsFilterSchema,
   ListApiKeysQuerySchema,
@@ -88,11 +91,6 @@ const authRouter = hono()
     zValidator('json', VaultInjectClaimsSchema),
     async (c) => {
       const userId = c.get('userId')!;
-
-      const { vaultName: name, environment } = c.req.valid('json');
-
-      const vaultName = await vaultNameFromUserId(userId, name);
-
       const clerkClient = c.get('clerk');
 
       const cap = c.get('planLimits')?.apiKeys;
@@ -115,6 +113,14 @@ const authRouter = hono()
           );
       }
 
+      const {
+        vaultName: name,
+        environment,
+        ...injectOptions
+      } = c.req.valid('json');
+
+      const vaultName = await vaultNameFromUserId(userId, name);
+
       // Reissuing for the same vault/environment is normal, and the
       // Clerk modal is the only place keys are told apart and revoked.
       const issuedAt = new Date()
@@ -122,15 +128,20 @@ const authRouter = hono()
         .replace(/[-:]/g, '')
         .replace(/T(\d{4}).*$/, '-$1');
 
+      // can be parameterized in the future
+      const scopes = [AuthScopes.VaultInject];
+      const claims: VaultInjectClaims = {
+        vaultName,
+        environment,
+        ...injectOptions,
+      };
+
       const apiKey = await clerkClient.apiKeys.create({
         name: `${name} (${environment}) ${issuedAt}`,
         description: `Used to inject ${environment} secrets from ${name} into CI/CD processes.`,
         subject: userId,
-        scopes: [AuthScopes.VaultInject],
-        claims: {
-          vaultName,
-          environment,
-        },
+        scopes,
+        claims,
       });
 
       // Clerk returns the plaintext only on create and stores it hashed,
@@ -138,7 +149,12 @@ const authRouter = hono()
       if (!apiKey.secret) return c.json(KeyNotIssued, 500);
 
       return c.json(
-        { id: apiKey.id, name: apiKey.name, key: apiKey.secret },
+        {
+          id: apiKey.id,
+          name: apiKey.name,
+          key: apiKey.secret,
+          claims,
+        },
         201,
       );
     },

--- a/worker/src/routers/vault.ts
+++ b/worker/src/routers/vault.ts
@@ -140,7 +140,7 @@ const vaultRouter = hono()
     AppRouteParts.CiTokens,
     apiKey({ scopes: [AuthScopes.VaultInject] }),
     async (c) => {
-      const { vaultName, environment } = c.get(
+      const { vaultName, environment, ...injectOptions } = c.get(
         'claims',
       )! as VaultInjectClaims;
 
@@ -159,6 +159,7 @@ const vaultRouter = hono()
           name: vaultName,
           token,
           environment,
+          ...injectOptions,
         };
 
         return c.json(creds, 201);

--- a/worker/tests/routers/auth-keys.spec.ts
+++ b/worker/tests/routers/auth-keys.spec.ts
@@ -178,6 +178,11 @@ describe('POST /auth/keys', () => {
       id: 'key_1',
       name: 'issued',
       key: 'sk_live_123',
+      // Echoed back so a caller can show what the key is scoped to.
+      claims: {
+        vaultName: 'hash13-demo',
+        environment: 'production',
+      },
     });
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Desktop vault UI work, a destructive-toggle fix, CI API key shaping claims, and the VS Code republish.

## Desktop vault

- Secret rows go from four cramped icons to reveal / edit / overflow. Editing is a modal that renames the key and changes its value in one place.
- Overflow menu adds `Copy to` (clipboard or another environment, marking replacements) and `Drop secret`, so sending one value no longer means sharing the whole vault.
- Click a name to copy the name, a revealed value to copy the value. Long values ellipsise at the pane edge instead of widening it.
- Secrets list shows a loading state instead of snapping from "No secrets yet" to full.

## Cloud sync toggle

Clicking `Synced` sent `DELETE /vault/:name`, destroying the Turso database and every token minted from it in one click, then provisioning an empty one on re-enable.

- Turning sync off is now local only; re-enabling reattaches to the existing database.
- Deleting the cloud copy moved behind its own dialog that requires typing the vault name.

## API key inject shaping

`deadrop apiKeys create` takes optional `--only` and `--prefix`. The claims ride with the key, so pipelines set `DEADROP_API_KEY` and get the right variables under the right names.

- A run may narrow what the key allows, never widen it. `inject --only` can pick a subset; naming anything outside fails. A disagreeing `inject --prefix` warns and the key's wins.
- Shaping only, not access control. Secrets never pass through the worker, so filtering is client side. Per-environment encryption keys are what separate environments; names stay visible across them, like a committed `.env.example`.

## VS Code

Republish for all platform targets. The 0.1.9 publish timed out partway through, leaving `linux-x64` and `win32-x64` missing with no universal build to fall back on. Publish now runs per target with retries.

## Not included

The Redis to Cloudflare KV refactor is held back for a separate platform release.
